### PR TITLE
Initial transmit api

### DIFF
--- a/examples/receiver/src/main.c
+++ b/examples/receiver/src/main.c
@@ -157,7 +157,8 @@ static etcpal_error_t create_listener(ListeningUniverse* listener, uint16_t univ
   config.universe_id = universe;
 
   printf("Creating a new sACN receiver on universe %u.\n", universe);
-  etcpal_error_t result = sacn_receiver_create(&config, &listener->receiver_handle);
+  //CHRISTIAN TODO: Checking interfaces?
+  etcpal_error_t result = sacn_receiver_create(&config, &listener->receiver_handle, NULL);
   if (result == kEtcPalErrOk)
   {
     listener->universe = universe;

--- a/examples/receiver/src/main.c
+++ b/examples/receiver/src/main.c
@@ -158,7 +158,7 @@ static etcpal_error_t create_listener(ListeningUniverse* listener, uint16_t univ
 
   printf("Creating a new sACN receiver on universe %u.\n", universe);
   //CHRISTIAN TODO: Checking interfaces?
-  etcpal_error_t result = sacn_receiver_create(&config, &listener->receiver_handle, NULL);
+  etcpal_error_t result = sacn_receiver_create(&config, &listener->receiver_handle, NULL, 0);
   if (result == kEtcPalErrOk)
   {
     listener->universe = universe;

--- a/include/sacn/common.h
+++ b/include/sacn/common.h
@@ -79,12 +79,29 @@ typedef struct SacnHeaderData
  * primary key for a network interface is simply a combination of the interface index and the IP
  * protocol used.
  */
-//TODO CHRISTIAN : This is identical to the RdmnetMcastNetintId.  They need to be merged into ETCPal as EtcPalMcastNetintId.
+// TODO CHRISTIAN : This is identical to the RdmnetMcastNetintId.  They need to be merged into ETCPal as
+// EtcPalMcastNetintId.
 typedef struct SacnMcastNetintId
 {
   etcpal_iptype_t ip_type; /*!< The IP protocol used on the network interface. */
   unsigned int index;      /*!< The OS index of the network interface. */
 } SacnMcastNetintId;
+
+/*! The functions on the source and receiver that involve creation and networking change
+ *   use this structure to indicate what interfaces were successfully created.
+ * */
+typedef struct SacnNetworkChangeResult
+{
+  /*! This array is owned by the application.  The library will fill in
+   *   the array with the list of successfully added network interfaces (only up to
+   *   the maximum size of the array).
+   */
+  SacnMcastNetintId* successful_interfaces;
+  /*! On input, this is the maximum size of successful_interfaces.
+   *   On output, this is the number of successful interfaces added by the library.  In the event that
+   *   successful_interfaces is too small for the entire list, this count is bounded by the passed in max. */
+  size_t successful_interfaces_count;
+} SacnNetworkChangeResult;
 
 etcpal_error_t sacn_init(const EtcPalLogParams* log_params);
 void sacn_deinit(void);

--- a/include/sacn/common.h
+++ b/include/sacn/common.h
@@ -98,8 +98,9 @@ typedef struct SacnNetworkChangeResult
    */
   SacnMcastNetintId* successful_interfaces;
   /*! On input, this is the maximum size of successful_interfaces.
-   *   On output, this is the number of successful interfaces added by the library.  In the event that
-   *   successful_interfaces is too small for the entire list, this count is bounded by the passed in max. */
+   *  On output, this is the number of successful interfaces added by the library.  In the event that
+   *  successful_interfaces is too small for the entire list, this count is bounded by the passed in max.
+   */
   size_t successful_interfaces_count;
 } SacnNetworkChangeResult;
 

--- a/include/sacn/common.h
+++ b/include/sacn/common.h
@@ -52,6 +52,15 @@ extern "C" {
 /*! The number of addresses in a DMX universe. */
 #define DMX_ADDRESS_COUNT 512
 
+/*!
+ * \brief The maximum number of network interfaces that can reported by the various create & reset_networking calls with
+ * a SacnNetworkChangeResult.
+ */
+#ifndef SACN_MAX_SUCCESSFUL_INTERFACES
+#define SACN_MAX_SUCCESSFUL_INTERFACES 20
+#endif
+
+
 /*! The data present in the header of an sACN data packet. */
 typedef struct SacnHeaderData
 {
@@ -92,14 +101,11 @@ typedef struct SacnMcastNetintId
  * */
 typedef struct SacnNetworkChangeResult
 {
-  /*! This array is owned by the application.  The library will fill in
-   *   the array with the list of successfully added network interfaces (only up to
-   *   the maximum size of the array).
+  /*! The library will fill in the array with the list of successfully added network interfaces (only up to
+   *  #SACN_MAX_SUCCESSFUL_INTERFACES).
    */
-  SacnMcastNetintId* successful_interfaces;
-  /*! On input, this is the maximum size of successful_interfaces.
-   *  On output, this is the number of successful interfaces added by the library.  In the event that
-   *  successful_interfaces is too small for the entire list, this count is bounded by the passed in max.
+  SacnMcastNetintId successful_interfaces [SACN_MAX_SUCCESSFUL_INTERFACES];
+  /*! On output, this is the number of successful interfaces added by the library, up to #SACN_MAX_SUCCESSFUL_INTERFACES.
    */
   size_t successful_interfaces_count;
 } SacnNetworkChangeResult;

--- a/include/sacn/common.h
+++ b/include/sacn/common.h
@@ -109,11 +109,11 @@ typedef struct SacnMcastNetintId
 * On input, this structure is used to indicate a network interface to use.
 * On output, this structure indicates whether or not the operation was a success.
 */
-typedef struct SacnMcastInterfaceToUse
+typedef struct SacnMcastInterface
 {
   SacnMcastNetintId iface;
   bool operation_succeeded;
-} SacnMcastInterfaceToUse;
+} SacnMcastInterface;
 
 etcpal_error_t sacn_init(const EtcPalLogParams* log_params);
 void sacn_deinit(void);

--- a/include/sacn/common.h
+++ b/include/sacn/common.h
@@ -52,15 +52,6 @@ extern "C" {
 /*! The number of addresses in a DMX universe. */
 #define DMX_ADDRESS_COUNT 512
 
-/*!
- * \brief The maximum number of network interfaces that can reported by the various create & reset_networking calls with
- * a SacnNetworkChangeResult.
- */
-#ifndef SACN_MAX_SUCCESSFUL_INTERFACES
-#define SACN_MAX_SUCCESSFUL_INTERFACES 20
-#endif
-
-
 /*! The data present in the header of an sACN data packet. */
 typedef struct SacnHeaderData
 {
@@ -96,19 +87,15 @@ typedef struct SacnMcastNetintId
   unsigned int index;      /*!< The OS index of the network interface. */
 } SacnMcastNetintId;
 
-/*! The functions on the source and receiver that involve creation and networking change
- *   use this structure to indicate what interfaces were successfully created.
- * */
-typedef struct SacnNetworkChangeResult
+/**
+* On input, this structure is used to indicate a network interface to use.
+* On output, this structure indicates whether or not the operation was a success.
+*/
+typedef struct SacnMcastInterfaceToUse
 {
-  /*! The library will fill in the array with the list of successfully added network interfaces (only up to
-   *  #SACN_MAX_SUCCESSFUL_INTERFACES).
-   */
-  SacnMcastNetintId successful_interfaces [SACN_MAX_SUCCESSFUL_INTERFACES];
-  /*! On output, this is the number of successful interfaces added by the library, up to #SACN_MAX_SUCCESSFUL_INTERFACES.
-   */
-  size_t successful_interfaces_count;
-} SacnNetworkChangeResult;
+  SacnMcastNetintId iface;
+  bool operation_succeeded;
+} SacnMcastInterfaceToUse;
 
 etcpal_error_t sacn_init(const EtcPalLogParams* log_params);
 void sacn_deinit(void);

--- a/include/sacn/common.h
+++ b/include/sacn/common.h
@@ -17,9 +17,9 @@
  * https://github.com/ETCLabs/sACN
  *****************************************************************************/
 
-/*!
- * \file sacn/common.h
- * \brief Common definitions for sACN
+/**
+ * @file sacn/common.h
+ * @brief Common definitions for sACN
  */
 
 #ifndef SACN_COMMON_H_
@@ -32,9 +32,9 @@
 #include "etcpal/log.h"
 #include "etcpal/uuid.h"
 
-/*!
- * \defgroup sACN sACN
- * \brief sACN: A Streaming ACN (sACN) implementation.
+/**
+ * @defgroup sACN sACN
+ * @brief sACN: A Streaming ACN (sACN) implementation.
  * @{
  */
 
@@ -42,38 +42,56 @@
 extern "C" {
 #endif
 
-/*!
- * \brief The maximum length of an sACN source name, including the null-terminator.
+/**
+ * @brief The maximum length of an sACN source name, including the null-terminator.
  *
  * E1.31 specifies that the Source Name field must be null-terminated on the wire.
  */
 #define SACN_SOURCE_NAME_MAX_LEN 64
 
-/*! The number of addresses in a DMX universe. */
+/**
+ * The number of addresses in a DMX universe.
+ */
 #define DMX_ADDRESS_COUNT 512
 
-/*! The data present in the header of an sACN data packet. */
+/**
+ * The data present in the header of an sACN data packet.
+ */
 typedef struct SacnHeaderData
 {
-  /*! The source's Component Identifier (CID). */
+  /**
+   * The source's Component Identifier (CID).
+   */
   EtcPalUuid cid;
-  /*! A user-assigned name for displaying the identity of a source. */
+  /**
+   * A user-assigned name for displaying the identity of a source.
+   */
   char source_name[SACN_SOURCE_NAME_MAX_LEN];
-  /*! The sACN Universe identifier. Valid range is 1-63999, inclusive. */
+  /**
+   * The sACN Universe identifier. Valid range is 1-63999, inclusive.
+   */
   uint16_t universe_id;
-  /*! The priority of the sACN data. Valid range is 0-200, inclusive. */
+  /**
+   * The priority of the sACN data. Valid range is 0-200, inclusive.
+   */
   uint8_t priority;
-  /*! Whether the Preview_Data bit is set for the sACN data. From E1.31: "Indicates that the data in
-   *  this packet is intended for use in visualization or media server preview applications and
-   *  shall not be used to generate live output." */
+  /**
+   * Whether the Preview_Data bit is set for the sACN data. From E1.31: "Indicates that the data in
+   * this packet is intended for use in visualization or media server preview applications and
+   * shall not be used to generate live output."
+   */
   bool preview;
-  /*! The start code of the DMX data. */
+  /**
+   * The start code of the DMX data.
+   */
   uint8_t start_code;
-  /*! The number of slots in the DMX data. */
+  /**
+   * The number of slots in the DMX data.
+   */
   uint16_t slot_count;
 } SacnHeaderData;
 
-/*!
+/**
  * A set of identifying information for a network interface, for multicast purposes. When creating
  * network sockets to use with multicast sACN, the interface IP addresses don't matter and the
  * primary key for a network interface is simply a combination of the interface index and the IP
@@ -83,8 +101,8 @@ typedef struct SacnHeaderData
 // EtcPalMcastNetintId.
 typedef struct SacnMcastNetintId
 {
-  etcpal_iptype_t ip_type; /*!< The IP protocol used on the network interface. */
-  unsigned int index;      /*!< The OS index of the network interface. */
+  etcpal_iptype_t ip_type; /**< The IP protocol used on the network interface. */
+  unsigned int index;      /**< The OS index of the network interface. */
 } SacnMcastNetintId;
 
 /**
@@ -104,7 +122,7 @@ void sacn_deinit(void);
 }
 #endif
 
-/*!
+/**
  * @}
  */
 

--- a/include/sacn/cpp/common.h
+++ b/include/sacn/cpp/common.h
@@ -20,59 +20,74 @@
 #ifndef SACN_CPP_COMMON_H_
 #define SACN_CPP_COMMON_H_
 
-/// @file sacn/cpp/common.h
-/// @brief C++ wrapper for the sACN init/deinit functions
+/**
+ * @file sacn/cpp/common.h
+ * @brief C++ wrapper for the sACN init/deinit functions
+ */
 
 #include "etcpal/cpp/error.h"
 #include "etcpal/cpp/log.h"
 #include "sacn/common.h"
 
-/// @defgroup sacn_cpp_api sACN C++ Language APIs
-/// @brief Native C++ APIs for interfacing with the sACN library.
-///
-/// These wrap the corresponding C modules in a nicer syntax for C++ application developers.
+/**
+ * @defgroup sacn_cpp_api sACN C++ Language APIs
+ * @brief Native C++ APIs for interfacing with the sACN library.
+ *
+ * These wrap the corresponding C modules in a nicer syntax for C++ application developers.
+ */
 
-/// @defgroup sacn_cpp_common Common Definitions
-/// @ingroup sacn_cpp_api
-/// @brief Definitions shared by other APIs in this module.
+/**
+ * @defgroup sacn_cpp_common Common Definitions
+ * @ingroup sacn_cpp_api
+ * @brief Definitions shared by other APIs in this module.
+ */
 
-/// @brief A namespace which contains all C++ language definitions in the sACN library.
+/**
+ * @brief A namespace which contains all C++ language definitions in the sACN library.
+ */
 namespace sacn
 {
-/// @ingroup sacn_cpp_common
-/// @brief Initialize the sACN library.
-///
-/// Wraps sacn_init(). Does all initialization required before the sACN API modules can be
-/// used.
-///
-/// @param log_params (optional) Log parameters for the sACN library to use to log messages. If
-///                   not provided, no logging will be performed.
-/// @return etcpal::Error::Ok(): Initialization successful.
-/// @return Errors from sacn_init().
+
+/**
+ * @ingroup sacn_cpp_common
+ * @brief Initialize the sACN library.
+ *
+ * Wraps sacn_init(). Does all initialization required before the sACN API modules can be
+ * used.
+ *
+ * @param log_params (optional) Log parameters for the sACN library to use to log messages. If
+ *                   not provided, no logging will be performed.
+ * @return etcpal::Error::Ok(): Initialization successful.
+ * @return Errors from sacn_init().
+ */
 inline etcpal::Error Init(const EtcPalLogParams* log_params = nullptr)
 {
   return sacn_init(log_params);
 }
 
-/// @ingroup sacn_cpp_common
-/// @brief Initialize the sACN library.
-///
-/// Wraps sacn_init(). Does all initialization required before the sACN API modules can be
-/// used.
-///
-/// @param logger Logger instance for the sACN library to use to log messages.
-/// @return etcpal::Error::Ok(): Initialization successful.
-/// @return Errors from sacn_init().
+/**
+ * @ingroup sacn_cpp_common
+ * @brief Initialize the sACN library.
+ *
+ * Wraps sacn_init(). Does all initialization required before the sACN API modules can be
+ * used.
+ *
+ * @param logger Logger instance for the sACN library to use to log messages.
+ * @return etcpal::Error::Ok(): Initialization successful.
+ * @return Errors from sacn_init().
+ */
 inline etcpal::Error Init(const etcpal::Logger& logger)
 {
   return sacn_init(&logger.log_params());
 }
 
-/// @ingroup sacn_cpp_common
-/// @brief Deinitialize the sACN library.
-///
-/// Closes all connections, deallocates all resources and joins the background thread. No sACN
-/// API functions are usable after this function is called.
+/**
+ * @ingroup sacn_cpp_common
+ * @brief Deinitialize the sACN library.
+ *
+ * Closes all connections, deallocates all resources and joins the background thread. No sACN
+ * API functions are usable after this function is called.
+ */
 inline void Deinit()
 {
   return sacn_deinit();

--- a/include/sacn/cpp/dmx_merger.h
+++ b/include/sacn/cpp/dmx_merger.h
@@ -20,114 +20,122 @@
 #ifndef SACN_CPP_DMX_MERGER_H_
 #define SACN_CPP_DMX_MERGER_H_
 
-/// @file sacn/cpp/dmx_merger.h
-/// @brief C++ wrapper for the sACN DMX Merger API
+/**
+ * @file sacn/cpp/dmx_merger.h
+ * @brief C++ wrapper for the sACN DMX Merger API
+ */
 
 #include "sacn/dmx_merger.h"
 #include "etcpal/cpp/inet.h"
 #include "etcpal/cpp/uuid.h"
 
-/// @defgroup sacn_dmx_merger_cpp sACN DMX Merger API
-/// @ingroup sacn_cpp_api
-/// @brief A C++ wrapper for the sACN DMX Merger API
+/**
+ * @defgroup sacn_dmx_merger_cpp sACN DMX Merger API
+ * @ingroup sacn_cpp_api
+ * @brief A C++ wrapper for the sACN DMX Merger API
+ */
 
 namespace sacn
 {
-/// @ingroup sacn_dmx_merger_cpp
-/// @brief An instance of sACN DMX Merger functionality.
-/// 
-/// This class instantiates software mergers for buffers containing DMX512-A start code 0 packets.
-/// It also uses buffers containing DMX512-A start code 0xdd packets to support per-address priority.
-/// 
-/// While this class is used to easily merge the outputs from the sACN Receiver API, it can also be used
-/// to merge your own DMX sources together, even in combination with the sources received via sACN.
-/// 
-/// When asked to calculate the merge, the merger will evaluate the current source
-/// buffers and update two result buffers:
-///  - 512 bytes for the merged data values (i.e. "winning level").  These are calculated by using
-///     a Highest-Level-Takes-Precedence(HTP) algorithm for all sources that share the highest
-///     per-address priority.
-///  - 512 source identifiers (i.e. "winning source") to indicate which source was considered the
-///     source of the merged data value, or that no source currently owns this address.
-/// 
-/// Usage:
-/// @code
-/// // These buffers are updated on each merger call with the merge results.
-/// // They must be valid as long as the merger is using them.
-/// uint8_t slots[DMX_ADDRESS_COUNT];
-/// sacn_source_id_t slot_owners[DMX_ADDRESS_COUNT];
-/// 
-/// // Merger configuration used for the initialization of each merger:
-/// sacn::DmxMerger::Settings settings(slots_, slot_owners_);
-/// 
-/// // A merger provides a handle for each of its sources. Source CIDs are tracked as well.
-/// sacn_source_id_t source_1_handle, source_2_handle;
-/// etcpal::Uuid source_1_cid, source_2_cid;
-/// // Initialize CIDs here...
-/// 
-/// // Initialize a merger and two sources, getting the source handles in return.
-/// sacn::DmxMerger merger;
-/// merger.Startup(settings);
-/// 
-/// // Make sure to check/handle error cases (this is omitted in this example).
-/// source_1_handle = merger.AddSource(source_1_cid).value();
-/// source_2_handle = merger.AddSource(source_2_cid).value();
-/// 
-/// // Input data for merging:
-/// uint8_t levels[DMX_ADDRESS_COUNT];
-/// uint8_t paps[DMX_ADDRESS_COUNT];
-/// uint8_t universe_priority;
-/// // Initialize levels, paps, and universe_priority here...
-/// 
-/// // Levels and PAPs can be merged separately:
-/// merger.UpdateSourceData(source_1_handle, universe_priority, levels, DMX_ADDRESS_COUNT);
-/// merger.UpdateSourceData(source_1_handle, universe_priority, nullptr, 0, paps, DMX_ADDRESS_COUNT);
-/// 
-/// // Or together in one call:
-/// merger.UpdateSourceData(source_2_handle, universe_priority, levels, DMX_ADDRESS_COUNT, paps, DMX_ADDRESS_COUNT);
-/// 
-/// // Or, if this is within a sACN receiver callback, use UpdateSourceDataFromSacn:
-/// SacnHeaderData header;
-/// uint8_t pdata[DMX_ADDRESS_COUNT];
-/// // Assuming header and pdata are initialized.
-///
-/// merger.UpdateSourceDataFromSacn(header, pdata);
-/// 
-/// // PAP can also be removed. Here, source 1 reverts to universe_priority:
-/// merger.StopSourcePerAddressPriority(source_1_handle);
-/// 
-/// // The read-only state of each source can be obtained as well.
-/// const SacnDmxMergerSource* source_1_state = merger.GetSourceInfo(source_1_handle);
-/// const SacnDmxMergerSource* source_2_state = merger.GetSourceInfo(source_2_handle);
-/// 
-/// // Do something with the merge results (slots and slot_owners)...
-/// 
-/// // Sources can be removed individually:
-/// merger.RemoveSource(source_1_handle);
-/// merger.RemoveSource(source_2_handle);
-/// 
-/// // However, when each merger is shut down, all of its sources are removed along with it:
-/// merger.Shutdown();
-/// @endcode
+/**
+ * @ingroup sacn_dmx_merger_cpp
+ * @brief An instance of sACN DMX Merger functionality.
+ * 
+ * This class instantiates software mergers for buffers containing DMX512-A start code 0 packets.
+ * It also uses buffers containing DMX512-A start code 0xdd packets to support per-address priority.
+ * 
+ * While this class is used to easily merge the outputs from the sACN Receiver API, it can also be used
+ * to merge your own DMX sources together, even in combination with the sources received via sACN.
+ * 
+ * When asked to calculate the merge, the merger will evaluate the current source
+ * buffers and update two result buffers:
+ *  - 512 bytes for the merged data values (i.e. "winning level").  These are calculated by using
+ *     a Highest-Level-Takes-Precedence(HTP) algorithm for all sources that share the highest
+ *     per-address priority.
+ *  - 512 source identifiers (i.e. "winning source") to indicate which source was considered the
+ *     source of the merged data value, or that no source currently owns this address.
+ * 
+ * Usage:
+ * @code
+ * // These buffers are updated on each merger call with the merge results.
+ * // They must be valid as long as the merger is using them.
+ * uint8_t slots[DMX_ADDRESS_COUNT];
+ * sacn_source_id_t slot_owners[DMX_ADDRESS_COUNT];
+ * 
+ * // Merger configuration used for the initialization of each merger:
+ * sacn::DmxMerger::Settings settings(slots_, slot_owners_);
+ * 
+ * // A merger provides a handle for each of its sources. Source CIDs are tracked as well.
+ * sacn_source_id_t source_1_handle, source_2_handle;
+ * etcpal::Uuid source_1_cid, source_2_cid;
+ * // Initialize CIDs here...
+ * 
+ * // Initialize a merger and two sources, getting the source handles in return.
+ * sacn::DmxMerger merger;
+ * merger.Startup(settings);
+ * 
+ * // Make sure to check/handle error cases (this is omitted in this example).
+ * source_1_handle = merger.AddSource(source_1_cid).value();
+ * source_2_handle = merger.AddSource(source_2_cid).value();
+ * 
+ * // Input data for merging:
+ * uint8_t levels[DMX_ADDRESS_COUNT];
+ * uint8_t paps[DMX_ADDRESS_COUNT];
+ * uint8_t universe_priority;
+ * // Initialize levels, paps, and universe_priority here...
+ * 
+ * // Levels and PAPs can be merged separately:
+ * merger.UpdateSourceData(source_1_handle, universe_priority, levels, DMX_ADDRESS_COUNT);
+ * merger.UpdateSourceData(source_1_handle, universe_priority, nullptr, 0, paps, DMX_ADDRESS_COUNT);
+ * 
+ * // Or together in one call:
+ * merger.UpdateSourceData(source_2_handle, universe_priority, levels, DMX_ADDRESS_COUNT, paps, DMX_ADDRESS_COUNT);
+ * 
+ * // Or, if this is within a sACN receiver callback, use UpdateSourceDataFromSacn:
+ * SacnHeaderData header;
+ * uint8_t pdata[DMX_ADDRESS_COUNT];
+ * // Assuming header and pdata are initialized.
+ *
+ * merger.UpdateSourceDataFromSacn(header, pdata);
+ * 
+ * // PAP can also be removed. Here, source 1 reverts to universe_priority:
+ * merger.StopSourcePerAddressPriority(source_1_handle);
+ * 
+ * // The read-only state of each source can be obtained as well.
+ * const SacnDmxMergerSource* source_1_state = merger.GetSourceInfo(source_1_handle);
+ * const SacnDmxMergerSource* source_2_state = merger.GetSourceInfo(source_2_handle);
+ * 
+ * // Do something with the merge results (slots and slot_owners)...
+ * 
+ * // Sources can be removed individually:
+ * merger.RemoveSource(source_1_handle);
+ * merger.RemoveSource(source_2_handle);
+ * 
+ * // However, when each merger is shut down, all of its sources are removed along with it:
+ * merger.Shutdown();
+ * @endcode
+ */
 class DmxMerger
 {
 public:
-  /// A handle type used by the sACN library to identify merger instances.
+  /** A handle type used by the sACN library to identify merger instances. */
   using Handle = sacn_dmx_merger_t;
-  /// An invalid Handle value.
+  /** An invalid Handle value. */
   static constexpr Handle kInvalidHandle = SACN_DMX_MERGER_INVALID;
 
-  /// @ingroup sacn_dmx_merger_cpp
-  /// @brief A set of configuration settings that a merger needs to initialize.
+  /**
+   * @ingroup sacn_dmx_merger_cpp
+   * @brief A set of configuration settings that a merger needs to initialize.
+   */
   struct Settings
   {
     /********* Required values **********/
 
-    /*! Buffer of #DMX_ADDRESS_COUNT levels that this library keeps up to date as it merges.
+    /** Buffer of #DMX_ADDRESS_COUNT levels that this library keeps up to date as it merges.
         Memory is owned by the application.*/
     uint8_t* slots{nullptr};
 
-    /*! Buffer of #DMX_ADDRESS_COUNT source IDs that indicate the current winner of the merge for
+    /** Buffer of #DMX_ADDRESS_COUNT source IDs that indicate the current winner of the merge for
         that slot, or #DMX_MERGER_SOURCE_INVALID to indicate that no source is providing values for that slot.
         You can use SACN_DMX_MERGER_SOURCE_IS_VALID(slot_owners, slot_index) if you don't want to look at the
         slot_owners directly.
@@ -136,10 +144,10 @@ public:
 
     /********* Optional values **********/
 
-    size_t source_count_max{SACN_RECEIVER_INFINITE_SOURCES};  ///< The maximum number of sources this universe will
-                                                              ///< listen to when using dynamic memory.
+    size_t source_count_max{SACN_RECEIVER_INFINITE_SOURCES}; /**< The maximum number of sources this universe will
+                                                                listen to when using dynamic memory. */
 
-    /// Create an empty, invalid data structure by default.
+    /** Create an empty, invalid data structure by default. */
     Settings() = default;
     Settings(uint8_t* slots_ptr, sacn_source_id_t* slot_owners_ptr);
 
@@ -149,8 +157,8 @@ public:
   DmxMerger() = default;
   DmxMerger(const DmxMerger& other) = delete;
   DmxMerger& operator=(const DmxMerger& other) = delete;
-  DmxMerger(DmxMerger&& other) = default;             ///< Move a dmx merger instance.
-  DmxMerger& operator=(DmxMerger&& other) = default;  ///< Move a dmx merger instance.
+  DmxMerger(DmxMerger&& other) = default;             /**< Move a dmx merger instance. */
+  DmxMerger& operator=(DmxMerger&& other) = default;  /**< Move a dmx merger instance. */
 
   etcpal::Error Startup(const Settings& settings);
   void Shutdown();
@@ -173,32 +181,36 @@ private:
   Handle handle_{kInvalidHandle};
 };
 
-/// @brief Create a DmxMerger Settings instance by passing the required members explicitly.
-///
-/// Optional members can be modified directly in the struct.
+/**
+ * @brief Create a DmxMerger Settings instance by passing the required members explicitly.
+ *
+ * Optional members can be modified directly in the struct.
+ */
 inline DmxMerger::Settings::Settings(uint8_t* slots_ptr, sacn_source_id_t* slot_owners_ptr)
     : slots(slots_ptr), slot_owners(slot_owners_ptr)
 {
 }
 
-/// Determine whether a DmxMerger Settings instance contains valid data for sACN operation.
+/**
+ * Determine whether a DmxMerger Settings instance contains valid data for sACN operation.
+ */
 inline bool DmxMerger::Settings::IsValid() const
 {
   return (slots && slot_owners);
 }
 
-/*!
- * \brief Create a new merger instance.
+/**
+ * @brief Create a new merger instance.
  *
  * Creates a new merger that uses the passed in config data.  The application owns all buffers
  * in the config, so be sure to call Shutdown() before destroying the buffers.
  *
- * \param[in] config Configuration parameters for the DMX merger to be created.
- * \return #kEtcPalErrOk: Merger created successful.
- * \return #kEtcPalErrInvalid: Invalid parameter provided.
- * \return #kEtcPalErrNotInit: Module not initialized.
- * \return #kEtcPalErrNoMem: No room to allocate memory for this merger, or maximum number of mergers has been reached.
- * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ * @param[in] config Configuration parameters for the DMX merger to be created.
+ * @return #kEtcPalErrOk: Merger created successful.
+ * @return #kEtcPalErrInvalid: Invalid parameter provided.
+ * @return #kEtcPalErrNotInit: Module not initialized.
+ * @return #kEtcPalErrNoMem: No room to allocate memory for this merger, or maximum number of mergers has been reached.
+ * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
 inline etcpal::Error DmxMerger::Startup(const Settings& settings)
 {
@@ -206,15 +218,15 @@ inline etcpal::Error DmxMerger::Startup(const Settings& settings)
   return sacn_dmx_merger_create(&config, &handle_);
 }
 
-/*!
- * \brief Destroy a merger instance.
+/**
+ * @brief Destroy a merger instance.
  *
  * Tears down the merger and cleans up its resources.
  *
- * \return #kEtcPalErrOk: Merger destroyed successfully.
- * \return #kEtcPalErrNotInit: Module not initialized.
- * \return #kEtcPalErrNotFound: Handle does not correspond to a valid merger.
- * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ * @return #kEtcPalErrOk: Merger destroyed successfully.
+ * @return #kEtcPalErrNotInit: Module not initialized.
+ * @return #kEtcPalErrNotFound: Handle does not correspond to a valid merger.
+ * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
 inline void DmxMerger::Shutdown()
 {
@@ -222,8 +234,8 @@ inline void DmxMerger::Shutdown()
   handle_ = kInvalidHandle;
 }
 
-/*!
- * \brief Adds a new source to the merger.
+/**
+ * @brief Adds a new source to the merger.
  *
  * Adds a new source to the merger, if the maximum number of sources hasn't been reached.
  * The returned source id is used for two purposes:
@@ -231,13 +243,13 @@ inline void DmxMerger::Shutdown()
  *   - It is the source identifer that is put into the slot_owners buffer that was passed
  *     in the DmxMergerUniverseConfig structure when creating the merger.
  *
- * \param[in] source_cid The sACN CID of the source.
- * \return The successfully added source_id.
- * \return #kEtcPalErrInvalid: Invalid parameter provided.
- * \return #kEtcPalErrNotInit: Module not initialized.
- * \return #kEtcPalErrNoMem: No room to allocate memory for this source, or the max number of sources has been reached.
- * \return #kEtcPalErrExists: the source at that cid was already added.
- * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ * @param[in] source_cid The sACN CID of the source.
+ * @return The successfully added source_id.
+ * @return #kEtcPalErrInvalid: Invalid parameter provided.
+ * @return #kEtcPalErrNotInit: Module not initialized.
+ * @return #kEtcPalErrNoMem: No room to allocate memory for this source, or the max number of sources has been reached.
+ * @return #kEtcPalErrExists: the source at that cid was already added.
+ * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
 inline etcpal::Expected<sacn_source_id_t> DmxMerger::AddSource(const etcpal::Uuid& source_cid)
 {
@@ -249,27 +261,27 @@ inline etcpal::Expected<sacn_source_id_t> DmxMerger::AddSource(const etcpal::Uui
     return err;
 }
 
-/*!
- * \brief Removes a source from the merger.
+/**
+ * @brief Removes a source from the merger.
  *
  * Removes the source from the merger.  This causes the merger to recalculate the outputs.
  *
- * \param[in] source The id of the source to remove.
- * \return #kEtcPalErrOk: Source removed successfully.
- * \return #kEtcPalErrInvalid: Invalid parameter provided.
- * \return #kEtcPalErrNotInit: Module not initialized.
- * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ * @param[in] source The id of the source to remove.
+ * @return #kEtcPalErrOk: Source removed successfully.
+ * @return #kEtcPalErrInvalid: Invalid parameter provided.
+ * @return #kEtcPalErrNotInit: Module not initialized.
+ * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
 inline etcpal::Error DmxMerger::RemoveSource(sacn_source_id_t source)
 {
   return sacn_dmx_merger_remove_source(handle_, source);
 }
 
-/*!
- * \brief Returns the source id for that source cid.
+/**
+ * @brief Returns the source id for that source cid.
  *
- * \param[in] source_cid The UUID of the source CID.
- * \return On success this will be the source ID, otherwise kEtcPalErrInvalid.
+ * @param[in] source_cid The UUID of the source CID.
+ * @return On success this will be the source ID, otherwise kEtcPalErrInvalid.
  */
 inline etcpal::Expected<sacn_source_id_t> DmxMerger::GetSourceId(const etcpal::Uuid& source_cid) const
 {
@@ -279,41 +291,41 @@ inline etcpal::Expected<sacn_source_id_t> DmxMerger::GetSourceId(const etcpal::U
   return kEtcPalErrInvalid;
 }
 
-/*!
- * \brief Gets a read-only view of the source data.
+/**
+ * @brief Gets a read-only view of the source data.
  *
  * Looks up the source data and returns a pointer to the data or nullptr if it doesn't exist.
  * This pointer is owned by the library, and must not be modified by the application.
  * The pointer will only be valid until the source or merger is removed.
  *
- * \param[in] source The id of the source.
- * \return The reference to the source data, otherwise kEtcPalErrInvalid.
+ * @param[in] source The id of the source.
+ * @return The reference to the source data, otherwise kEtcPalErrInvalid.
  */
 inline const SacnDmxMergerSource* DmxMerger::GetSourceInfo(sacn_source_id_t source) const
 {
   return sacn_dmx_merger_get_source(handle_, source);
 }
 
-/*!
- * \brief Updates the source data and recalculate outputs.
+/**
+ * @brief Updates the source data and recalculate outputs.
  *
  * The direct method to change source data.  This causes the merger to recalculate the outputs.
  * If you are processing sACN packets, you may prefer UpdateSourceDataFromSacn().
  *
- * \param[in] source The id of the source to modify.
- * \param[in] priority The universe-level priority of the source.
- * \param[in] new_values The new DMX values to be copied in. This must be nullptr if the source is not updating DMX
+ * @param[in] source The id of the source to modify.
+ * @param[in] priority The universe-level priority of the source.
+ * @param[in] new_values The new DMX values to be copied in. This must be nullptr if the source is not updating DMX
  * data.
- * \param[in] new_values_count The length of new_values. Must be 0 if the source is not updating DMX data.
- * \param[in] address_priorities The per-address priority values to be copied in.  This must be nullptr if the source is
+ * @param[in] new_values_count The length of new_values. Must be 0 if the source is not updating DMX data.
+ * @param[in] address_priorities The per-address priority values to be copied in.  This must be nullptr if the source is
  * not updating per-address priority data.
- * \param[in] address_priorities_count The length of address_priorities.  Must be 0 if the source is not updating
+ * @param[in] address_priorities_count The length of address_priorities.  Must be 0 if the source is not updating
  * per-address priority data.
- * \return #kEtcPalErrOk: Source updated and merge completed.
- * \return #kEtcPalErrInvalid: Invalid parameter provided.
- * \return #kEtcPalErrNotInit: Module not initialized.
- * \return #kEtcPalErrNotFound: Handle does not correspond to a valid source or merger.
- * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ * @return #kEtcPalErrOk: Source updated and merge completed.
+ * @return #kEtcPalErrInvalid: Invalid parameter provided.
+ * @return #kEtcPalErrNotInit: Module not initialized.
+ * @return #kEtcPalErrNotFound: Handle does not correspond to a valid source or merger.
+ * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
 inline etcpal::Error DmxMerger::UpdateSourceData(sacn_source_id_t source, uint8_t priority, const uint8_t* new_values,
                                                  size_t new_values_count, const uint8_t* address_priorities,
@@ -323,48 +335,48 @@ inline etcpal::Error DmxMerger::UpdateSourceData(sacn_source_id_t source, uint8_
                                             address_priorities_count);
 }
 
-/*!
- * \brief Updates the source data from a sACN packet and recalculate outputs.
+/**
+ * @brief Updates the source data from a sACN packet and recalculate outputs.
  *
  * Processes data passed from the sACN receiver's SacnUniverseDataCallback() handler.  This causes the merger to
  * recalculate the outputs.
  *
- * \param[in] header The sACN header.
- * \param[in] pdata The sACN data.
- * \return #kEtcPalErrOk: Source updated and merge completed.
- * \return #kEtcPalErrInvalid: Invalid parameter provided.
- * \return #kEtcPalErrNotInit: Module not initialized.
- * \return #kEtcPalErrNotFound: Handle does not correspond to a valid merger, or source CID in the header doesn't match
+ * @param[in] header The sACN header.
+ * @param[in] pdata The sACN data.
+ * @return #kEtcPalErrOk: Source updated and merge completed.
+ * @return #kEtcPalErrInvalid: Invalid parameter provided.
+ * @return #kEtcPalErrNotInit: Module not initialized.
+ * @return #kEtcPalErrNotFound: Handle does not correspond to a valid merger, or source CID in the header doesn't match
  * a known source.
- * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
 inline etcpal::Error DmxMerger::UpdateSourceDataFromSacn(const SacnHeaderData& header, const uint8_t* pdata)
 {
   return sacn_dmx_merger_update_source_from_sacn(handle_, &header, pdata);
 }
 
-/*!
- * \brief Removes the per-address data from the source and recalculate outputs.
+/**
+ * @brief Removes the per-address data from the source and recalculate outputs.
  *
  * Per-address priority data can time out in sACN just like values.
  * This is a convenience function to immediately turn off the per-address priority data for a source and recalculate the
  * outputs.
  *
- * \param[in] source The id of the source to modify.
- * \return #kEtcPalErrOk: Source updated and merge completed.
- * \return #kEtcPalErrNotFound: Handle does not correspond to a valid source or merger.
- * \return #kEtcPalErrNotInit: Module not initialized.
- * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ * @param[in] source The id of the source to modify.
+ * @return #kEtcPalErrOk: Source updated and merge completed.
+ * @return #kEtcPalErrNotFound: Handle does not correspond to a valid source or merger.
+ * @return #kEtcPalErrNotInit: Module not initialized.
+ * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
 inline etcpal::Error DmxMerger::StopSourcePerAddressPriority(sacn_source_id_t source)
 {
   return sacn_dmx_merger_stop_source_per_address_priority(handle_, source);
 }
 
-/*!
- * \brief Get the current handle to the underlying C sacn_receiver.
+/**
+ * @brief Get the current handle to the underlying C sacn_receiver.
  *
- * \return The handle or Receiver::kInvalidHandle.
+ * @return The handle or Receiver::kInvalidHandle.
  */
 inline constexpr DmxMerger::Handle DmxMerger::handle() const
 {

--- a/include/sacn/cpp/merge_receiver.h
+++ b/include/sacn/cpp/merge_receiver.h
@@ -143,11 +143,11 @@ public:
   MergeReceiver& operator=(MergeReceiver&& other) = default;  /**< Move a merge receiver instance. */
 
   etcpal::Error Startup(const Settings& settings, NotifyHandler& notify_handler,
-                        std::vector<SacnMcastInterfaceToUse>& ifaces);
+                        std::vector<SacnMcastInterface>& netints);
   void Shutdown();
   etcpal::Expected<uint16_t> GetUniverse() const;
   etcpal::Error ChangeUniverse(uint16_t new_universe_id);
-  etcpal::Error ResetNetworking(std::vector<SacnMcastInterfaceToUse>& ifaces);
+  etcpal::Error ResetNetworking(std::vector<SacnMcastInterface>& netints);
 
   etcpal::Expected<sacn_source_id_t> GetSourceId(const etcpal::Uuid& source_cid) const;
   etcpal::Expected<etcpal::Uuid> GetSourceCid(sacn_source_id_t source) const;
@@ -230,7 +230,7 @@ inline bool MergeReceiver::Settings::IsValid() const
  *
  * @param[in] settings Configuration parameters for the sACN merge receiver and this class instance.
  * @param[in] notify_handler The notification interface to call back to the application.
- * @param[in, out] ifaces Optional. If !empty, this is the list of interfaces the application wants to use, and the
+ * @param[in, out] netints Optional. If !empty, this is the list of interfaces the application wants to use, and the
  * operation_succeeded flags are filled in.  If empty, all available interfaces are tried and this vector isn't modified.
  * @return #kEtcPalErrOk: Merge Receiver created successfully.
  * @return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.
@@ -242,14 +242,14 @@ inline bool MergeReceiver::Settings::IsValid() const
  * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
 inline etcpal::Error MergeReceiver::Startup(const Settings& settings, NotifyHandler& notify_handler,
-                                            std::vector<SacnMcastInterfaceToUse>& ifaces)
+                                            std::vector<SacnMcastInterface>& netints)
 {
   SacnMergeReceiverConfig config = TranslateConfig(settings, notify_handler);
 
-  if(ifaces.empty())
+  if(netints.empty())
     return sacn_merge_receiver_create(&config, &handle_, NULL, 0);
   
-  return sacn_merge_receiver_create(&config, &handle_, ifaces.data(), ifaces.size());
+  return sacn_merge_receiver_create(&config, &handle_, netints.data(), netints.size());
 }
 
 /**
@@ -311,7 +311,7 @@ inline etcpal::Error MergeReceiver::ChangeUniverse(uint16_t new_universe_id)
  * Note that the networking reset is considered successful if it is able to successfully use any of the
  * network interfaces passed in.  This will only return #kEtcPalErrNoNetints if none of the interfaces work.
  *
- * @param[in, out] ifaces Optional. If !empty, this is the list of interfaces the application wants to use, and the
+ * @param[in, out] netints Optional. If !empty, this is the list of interfaces the application wants to use, and the
  * operation_succeeded flags are filled in.  If empty, all available interfaces are tried and this vector isn't modified.
  * @return #kEtcPalErrOk: Universe changed successfully.
  * @return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.
@@ -320,12 +320,12 @@ inline etcpal::Error MergeReceiver::ChangeUniverse(uint16_t new_universe_id)
  * @return #kEtcPalErrNotFound: Handle does not correspond to a valid merge receiver.
  * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
-inline etcpal::Error MergeReceiver::ResetNetworking(std::vector<SacnMcastInterfaceToUse>& ifaces)
+inline etcpal::Error MergeReceiver::ResetNetworking(std::vector<SacnMcastInterface>& netints)
 {
-  if (ifaces.empty())
+  if (netints.empty())
     return sacn_merge_receiver_reset_networking(handle_, nullptr, 0);
 
-  return sacn_merge_receiver_reset_networking(handle_, ifaces.data(), ifaces.size());
+  return sacn_merge_receiver_reset_networking(handle_, netints.data(), netints.size());
 }
 
 /**

--- a/include/sacn/cpp/merge_receiver.h
+++ b/include/sacn/cpp/merge_receiver.h
@@ -218,7 +218,7 @@ inline bool MergeReceiver::Settings::IsValid() const
  *
  * \param[in] settings Configuration parameters for the sACN merge receiver and this class instance.
  * \param[in] notify_handler The notification interface to call back to the application.
- * \param[in, out] good_interfaces Optional. If non-nil, good_interfaces is filled in with the list of network
+ * \param[out] good_interfaces Optional. If non-nil, good_interfaces is filled in with the list of network
  * interfaces that were succesfully used.
  * \return #kEtcPalErrOk: Merge Receiver created successfully.
  * \return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.
@@ -297,7 +297,7 @@ inline etcpal::Error MergeReceiver::ChangeUniverse(uint16_t new_universe_id)
  *
  * \param[in] netints Vector of network interfaces on which to listen to the specified universe. If empty,
  *  all available network interfaces will be used.
- * \param[in, out] good_interfaces Optional. If non-nil, good_interfaces is filled in with the list of network
+ * \param[ out] good_interfaces Optional. If non-nil, good_interfaces is filled in with the list of network
  * interfaces that were succesfully used.
  * \return #kEtcPalErrOk: Universe changed successfully.
  * \return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.

--- a/include/sacn/cpp/merge_receiver.h
+++ b/include/sacn/cpp/merge_receiver.h
@@ -20,40 +20,47 @@
 #ifndef SACN_CPP_MERGE_RECEIVER_H_
 #define SACN_CPP_MERGE_RECEIVER_H_
 
-/// @file sacn/cpp/merge_receiver.h
-/// @brief C++ wrapper for the sACN Merge Receiver API
+/**
+ * @file sacn/cpp/merge_receiver.h
+ * @brief C++ wrapper for the sACN Merge Receiver API
+ */
 
 #include "sacn/merge_receiver.h"
 #include "etcpal/cpp/inet.h"
 #include "etcpal/cpp/uuid.h"
 
-/// @defgroup sacn_merge_receiver_cpp sACN Merge Receiver API
-/// @ingroup sacn_cpp_api
-/// @brief A C++ wrapper for the sACN Merge Receiver API
+/**
+ * @defgroup sacn_merge_receiver_cpp sACN Merge Receiver API
+ * @ingroup sacn_cpp_api
+ * @brief A C++ wrapper for the sACN Merge Receiver API
+ */
 
 namespace sacn
 {
-/// @ingroup sacn_merge_receiver_cpp
-/// @brief An instance of sACN Merge Receiver functionality.
-///
-/// CHRISTIAN TODO: FILL OUT THIS COMMENT MORE -- DO WE NEED A using_merge_receiver.md, or one giant using_receiver.md???
+/**
+ * @ingroup sacn_merge_receiver_cpp
+ * @brief An instance of sACN Merge Receiver functionality.
+ */
+// CHRISTIAN TODO: FILL OUT THIS COMMENT MORE -- DO WE NEED A using_merge_receiver.md, or one giant using_receiver.md???
 class MergeReceiver
 {
 public:
-  /// A handle type used by the sACN library to identify merge receiver instances.
+  /** A handle type used by the sACN library to identify merge receiver instances. */
   using Handle = sacn_merge_receiver_t;
-  /// An invalid Handle value.
+  /** An invalid Handle value. */
   static constexpr Handle kInvalidHandle = SACN_MERGE_RECEIVER_INVALID;
 
-  /// @ingroup sacn_merge_receiver_cpp
-  /// @brief A base class for a class that receives notification callbacks from a sACN merge receiver.
+  /**
+   * @ingroup sacn_merge_receiver_cpp
+   * @brief A base class for a class that receives notification callbacks from a sACN merge receiver.
+   */
   class NotifyHandler
   {
   public:
     virtual ~NotifyHandler() = default;
 
-    /*!
-     * \brief Notify that a new data packet has been received and merged.
+    /**
+     * @brief Notify that a new data packet has been received and merged.
      *
      * This callback will be called in multiple ways:
      * 1. When a new non-preview data packet or per-address priority packet is received from the sACN Receiver module,
@@ -67,18 +74,18 @@ public:
      * This callback should be processed quickly, since it will interfere with the receipt and processing of other sACN
      * packets on the universe.
      *
-     * \param[in] universe The universe this merge receiver is monitoring.
-     * \param[in] slots Buffer of #DMX_ADDRESS_COUNT bytes containing the merged levels for the universe.  This buffer
+     * @param[in] universe The universe this merge receiver is monitoring.
+     * @param[in] slots Buffer of #DMX_ADDRESS_COUNT bytes containing the merged levels for the universe.  This buffer
      *                  is owned by the library.
-     * \param[in] slot_owners Buffer of #DMX_ADDRESS_COUNT source_ids.  If a value in the buffer is
+     * @param[in] slot_owners Buffer of #DMX_ADDRESS_COUNT source_ids.  If a value in the buffer is
      *           #DMX_MERGER_SOURCE_INVALID, the corresponding slot is not currently controlled. You can also use
      *            SACN_DMX_MERGER_SOURCE_IS_VALID(slot_owners, index) to check the slot validity. This buffer is owned
      *            by the library.
      */
     virtual void HandleMergedData(uint16_t universe, const uint8_t* slots, const sacn_source_id_t* slot_owners) = 0;
 
-    /*!
-     * \brief Notify that a non-data packet has been received.
+    /**
+     * @brief Notify that a non-data packet has been received.
      *
      * When an established source sends a sACN data packet that doesn't contain DMX values or priorities, the raw packet
      * is immediately and synchronously passed to this callback.
@@ -86,40 +93,43 @@ public:
      * This callback should be processed quickly, since it will interfere with the receipt and processing of other sACN
      * packets on the universe.
      *
-     * \param[in] universe The universe this merge receiver is monitoring.
-     * \param[in] source_addr The network address from which the sACN packet originated.
-     * \param[in] header The header data of the sACN packet.
-     * \param[in] pdata Pointer to the data buffer. Size of the buffer is indicated by header->slot_count. This buffer
+     * @param[in] universe The universe this merge receiver is monitoring.
+     * @param[in] source_addr The network address from which the sACN packet originated.
+     * @param[in] header The header data of the sACN packet.
+     * @param[in] pdata Pointer to the data buffer. Size of the buffer is indicated by header->slot_count. This buffer
      *                  is owned by the library.
      */
     virtual void HandleNonDmxData(uint16_t universe, const etcpal::SockAddr& source_addr,
                                     const SacnHeaderData& header, const uint8_t* pdata) = 0;
 
-    /*!
-     * \brief Notify that more than the configured maximum number of sources are currently sending on
+    /**
+     * @brief Notify that more than the configured maximum number of sources are currently sending on
      *        the universe being listened to.
      *
      * This is a notification that is directly forwarded from the sACN Receiver module.
      *
-     * \param[in] universe The universe this merge receiver is monitoring.
+     * @param[in] universe The universe this merge receiver is monitoring.
      */
     virtual void HandleSourceLimitExceeded(uint16_t universe) = 0;
   };
 
-  /// @ingroup sacn_merge_receiver_cpp
-  /// @brief A set of configuration settings that a merge receiver needs to initialize.
+  /**
+   * @ingroup sacn_merge_receiver_cpp
+   * @brief A set of configuration settings that a merge receiver needs to initialize.
+   */
   struct Settings
   {
     /********* Required values **********/
 
-    uint16_t universe_id{0};  ///< The sACN universe number the merge receiver is listening to.
+    /** The sACN universe number the merge receiver is listening to. */
+    uint16_t universe_id{0};
 
     /********* Optional values **********/
 
-    /// The maximum number of sources this universe will listen to when using dynamic memory.
+    /** The maximum number of sources this universe will listen to when using dynamic memory. */
     size_t source_count_max{SACN_RECEIVER_INFINITE_SOURCES};
 
-    /// Create an empty, invalid data structure by default.
+    /** Create an empty, invalid data structure by default. */
     Settings() = default;
     Settings(uint16_t new_universe_id);
 
@@ -129,8 +139,8 @@ public:
   MergeReceiver() = default;
   MergeReceiver(const MergeReceiver& other) = delete;
   MergeReceiver& operator=(const MergeReceiver& other) = delete;
-  MergeReceiver(MergeReceiver&& other) = default;             ///< Move a merge receiver instance.
-  MergeReceiver& operator=(MergeReceiver&& other) = default;  ///< Move a merge receiver instance.
+  MergeReceiver(MergeReceiver&& other) = default;             /**< Move a merge receiver instance. */
+  MergeReceiver& operator=(MergeReceiver&& other) = default;  /**< Move a merge receiver instance. */
 
   etcpal::Error Startup(const Settings& settings, NotifyHandler& notify_handler,
                         std::vector<SacnMcastInterfaceToUse>& ifaces);
@@ -150,8 +160,10 @@ private:
   Handle handle_{kInvalidHandle};
 };
 
-/// @cond device_c_callbacks
-/// Callbacks from underlying device library to be forwarded
+/**
+ * @cond device_c_callbacks
+ * Callbacks from underlying device library to be forwarded
+ */
 namespace internal
 {
 extern "C" inline void MergeReceiverCbMergedData(sacn_merge_receiver_t handle, uint16_t universe, const uint8_t* slots,
@@ -188,23 +200,27 @@ extern "C" inline void MergeReceiverCbSourceLimitExceeded(sacn_merge_receiver_t 
 
 };  // namespace internal
 
-/// @endcond
+/**
+ * @endcond
+ */
 
-/// @brief Create a MergeReceiver Settings instance by passing the required members explicitly.
-///
-/// Optional members can be modified directly in the struct.
+/**
+ * @brief Create a MergeReceiver Settings instance by passing the required members explicitly.
+ *
+ * Optional members can be modified directly in the struct.
+ */
 inline MergeReceiver::Settings::Settings(uint16_t new_universe_id) : universe_id(new_universe_id)
 {
 }
 
-/// Determine whether a MergeReciever Settings instance contains valid data for sACN operation.
+/** Determine whether a MergeReciever Settings instance contains valid data for sACN operation. */
 inline bool MergeReceiver::Settings::IsValid() const
 {
   return (universe_id > 0);
 }
 
-/*!
- * \brief Start listening for sACN data on a universe.
+/**
+ * @brief Start listening for sACN data on a universe.
  *
  * An sACN merge receiver can listen on one universe at a time, and each universe can only be listened to
  * by one merge receiver at at time.
@@ -212,18 +228,18 @@ inline bool MergeReceiver::Settings::IsValid() const
  * Note that a merge receiver is considered as successfully created if it is able to successfully use any of the
  * network interfaces passed in.  This will only return #kEtcPalErrNoNetints if none of the interfaces work.
  *
- * \param[in] settings Configuration parameters for the sACN merge receiver and this class instance.
- * \param[in] notify_handler The notification interface to call back to the application.
- * \param[in, out] ifaces Optional. If !empty, this is the list of interfaces the application wants to use, and the
+ * @param[in] settings Configuration parameters for the sACN merge receiver and this class instance.
+ * @param[in] notify_handler The notification interface to call back to the application.
+ * @param[in, out] ifaces Optional. If !empty, this is the list of interfaces the application wants to use, and the
  * operation_succeeded flags are filled in.  If empty, all available interfaces are tried and this vector isn't modified.
- * \return #kEtcPalErrOk: Merge Receiver created successfully.
- * \return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.
- * \return #kEtcPalErrInvalid: Invalid parameter provided.
- * \return #kEtcPalErrNotInit: Module not initialized.
- * \return #kEtcPalErrExists: A merge receiver already exists which is listening on the specified universe.
- * \return #kEtcPalErrNoMem: No room to allocate memory for this merge receiver, or maximum merge receivers reached.
- * \return #kEtcPalErrNotFound: A network interface ID given was not found on the system.
- * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ * @return #kEtcPalErrOk: Merge Receiver created successfully.
+ * @return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.
+ * @return #kEtcPalErrInvalid: Invalid parameter provided.
+ * @return #kEtcPalErrNotInit: Module not initialized.
+ * @return #kEtcPalErrExists: A merge receiver already exists which is listening on the specified universe.
+ * @return #kEtcPalErrNoMem: No room to allocate memory for this merge receiver, or maximum merge receivers reached.
+ * @return #kEtcPalErrNotFound: A network interface ID given was not found on the system.
+ * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
 inline etcpal::Error MergeReceiver::Startup(const Settings& settings, NotifyHandler& notify_handler,
                                             std::vector<SacnMcastInterfaceToUse>& ifaces)
@@ -236,8 +252,8 @@ inline etcpal::Error MergeReceiver::Startup(const Settings& settings, NotifyHand
   return sacn_merge_receiver_create(&config, &handle_, ifaces.data(), ifaces.size());
 }
 
-/*!
- * \brief Stop listening for sACN data on a universe.
+/**
+ * @brief Stop listening for sACN data on a universe.
  *
  * Tears down the merge receiver and any sources currently being tracked on the merge receiver's universe.
  * Stops listening for sACN on that universe.
@@ -248,10 +264,10 @@ inline void MergeReceiver::Shutdown()
   handle_ = kInvalidHandle;
 }
 
-/*!
- * \brief Get the universe this class is listening to.
+/**
+ * @brief Get the universe this class is listening to.
  *
- * \return If valid, the value is the universe id.  Otherwise, this is the underlying error the C library call returned.
+ * @return If valid, the value is the universe id.  Otherwise, this is the underlying error the C library call returned.
  */
 etcpal::Expected<uint16_t> MergeReceiver::GetUniverse() const
 {
@@ -263,28 +279,28 @@ etcpal::Expected<uint16_t> MergeReceiver::GetUniverse() const
     return err;
 }
 
-/*!
- * \brief Change the universe this class is listening to.
+/**
+ * @brief Change the universe this class is listening to.
  *
  * An sACN merge receiver can only listen on one universe at a time. After this call completes successfully, the merge
  * receiver is in a sampling period for the new universe and will provide HandleSourcesFound() calls when appropriate.
  * If this call fails, the caller must call Shutdown() on this class, because it may be in an invalid state.
  *
- * \param[in] new_universe_id New universe number that this merge receiver should listen to.
- * \return #kEtcPalErrOk: Universe changed successfully.
- * \return #kEtcPalErrInvalid: Invalid parameter provided.
- * \return #kEtcPalErrNotInit: Module not initialized.
- * \return #kEtcPalErrExists: A merge receiver already exists which is listening on the specified new universe.
- * \return #kEtcPalErrNotFound: Handle does not correspond to a valid merge receiver.
- * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ * @param[in] new_universe_id New universe number that this merge receiver should listen to.
+ * @return #kEtcPalErrOk: Universe changed successfully.
+ * @return #kEtcPalErrInvalid: Invalid parameter provided.
+ * @return #kEtcPalErrNotInit: Module not initialized.
+ * @return #kEtcPalErrExists: A merge receiver already exists which is listening on the specified new universe.
+ * @return #kEtcPalErrNotFound: Handle does not correspond to a valid merge receiver.
+ * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
 inline etcpal::Error MergeReceiver::ChangeUniverse(uint16_t new_universe_id)
 {
   return sacn_merge_receiver_change_universe(handle_, new_universe_id);
 }
 
-/*!
- * \brief Resets the underlying network sockets and packet receipt state for this class..
+/**
+ * @brief Resets the underlying network sockets and packet receipt state for this class..
  *
  * This is typically used when the application detects that the list of networking interfaces has changed.
  *
@@ -295,14 +311,14 @@ inline etcpal::Error MergeReceiver::ChangeUniverse(uint16_t new_universe_id)
  * Note that the networking reset is considered successful if it is able to successfully use any of the
  * network interfaces passed in.  This will only return #kEtcPalErrNoNetints if none of the interfaces work.
  *
- * \param[in, out] ifaces Optional. If !empty, this is the list of interfaces the application wants to use, and the
+ * @param[in, out] ifaces Optional. If !empty, this is the list of interfaces the application wants to use, and the
  * operation_succeeded flags are filled in.  If empty, all available interfaces are tried and this vector isn't modified.
- * \return #kEtcPalErrOk: Universe changed successfully.
- * \return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.
- * \return #kEtcPalErrInvalid: Invalid parameter provided.
- * \return #kEtcPalErrNotInit: Module not initialized.
- * \return #kEtcPalErrNotFound: Handle does not correspond to a valid merge receiver.
- * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ * @return #kEtcPalErrOk: Universe changed successfully.
+ * @return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.
+ * @return #kEtcPalErrInvalid: Invalid parameter provided.
+ * @return #kEtcPalErrNotInit: Module not initialized.
+ * @return #kEtcPalErrNotFound: Handle does not correspond to a valid merge receiver.
+ * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
 inline etcpal::Error MergeReceiver::ResetNetworking(std::vector<SacnMcastInterfaceToUse>& ifaces)
 {
@@ -312,11 +328,11 @@ inline etcpal::Error MergeReceiver::ResetNetworking(std::vector<SacnMcastInterfa
   return sacn_merge_receiver_reset_networking(handle_, ifaces.data(), ifaces.size());
 }
 
-/*!
- * \brief Returns the source id for that source cid.
+/**
+ * @brief Returns the source id for that source cid.
  *
- * \param[in] source_cid The UUID of the source CID.
- * \return On success this will be the source ID, otherwise kEtcPalErrInvalid.
+ * @param[in] source_cid The UUID of the source CID.
+ * @return On success this will be the source ID, otherwise kEtcPalErrInvalid.
  */
 inline etcpal::Expected<sacn_source_id_t> MergeReceiver::GetSourceId(const etcpal::Uuid& source_cid) const
 {
@@ -326,11 +342,11 @@ inline etcpal::Expected<sacn_source_id_t> MergeReceiver::GetSourceId(const etcpa
   return kEtcPalErrInvalid;
 }
 
-/*!
- * \brief Returns the source cid for that source id.
+/**
+ * @brief Returns the source cid for that source id.
  *
- * \param[in] source_id The id of the source.
- * \return On success this will be the source CID, otherwise kEtcPalErrInvalid.
+ * @param[in] source_id The id of the source.
+ * @return On success this will be the source CID, otherwise kEtcPalErrInvalid.
  */
 inline etcpal::Expected<etcpal::Uuid> MergeReceiver::GetSourceCid(sacn_source_id_t source_id) const
 {
@@ -340,10 +356,10 @@ inline etcpal::Expected<etcpal::Uuid> MergeReceiver::GetSourceCid(sacn_source_id
   return kEtcPalErrInvalid;
 }
 
-/*!
- * \brief Get the current handle to the underlying C merge receiver.
+/**
+ * @brief Get the current handle to the underlying C merge receiver.
  *
- * \return The handle or Receiver::kInvalidHandle.
+ * @return The handle or Receiver::kInvalidHandle.
  */
 inline constexpr MergeReceiver::Handle MergeReceiver::handle() const
 {

--- a/include/sacn/cpp/receiver.h
+++ b/include/sacn/cpp/receiver.h
@@ -224,7 +224,7 @@ inline bool Receiver::Settings::IsValid() const
  *
  * \param[in] settings Configuration parameters for the sACN receiver and this class instance.
  * \param[in] notify_handler The notification interface to call back to the application.
- * \param[in, out] good_interfaces Optional. If non-nil, good_interfaces is filled in with the list of network
+ * \param[out] good_interfaces Optional. If non-nil, good_interfaces is filled in with the list of network
  * interfaces that were succesfully used.
  * \return #kEtcPalErrOk: Receiver created successfully.
  * \return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.
@@ -303,7 +303,7 @@ inline etcpal::Error Receiver::ChangeUniverse(uint16_t new_universe_id)
  *
  * \param[in] netints Vector of network interfaces on which to listen to the specified universe. If empty,
  *  all available network interfaces will be used.
- * \param[in, out] good_interfaces Optional. If non-nil, good_interfaces is filled in with the list of network
+ * \param[out] good_interfaces Optional. If non-nil, good_interfaces is filled in with the list of network
  * interfaces that were succesfully used.
  * \return #kEtcPalErrOk: Universe changed successfully.
  * \return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.

--- a/include/sacn/cpp/receiver.h
+++ b/include/sacn/cpp/receiver.h
@@ -131,11 +131,11 @@ public:
   Receiver& operator=(Receiver&& other) = default;  /**< Move a device instance. */
 
   etcpal::Error Startup(const Settings& settings, NotifyHandler& notify_handler,
-                        std::vector<SacnMcastInterfaceToUse>& ifaces);
+                        std::vector<SacnMcastInterface>& netints);
   void Shutdown();
   etcpal::Expected<uint16_t> GetUniverse() const;
   etcpal::Error ChangeUniverse(uint16_t new_universe_id);
-  etcpal::Error ResetNetworking(std::vector<SacnMcastInterfaceToUse>& ifaces);
+  etcpal::Error ResetNetworking(std::vector<SacnMcastInterface>& netints);
 
   // Lesser used functions.  These apply to all instances of this class.
   static void SetStandardVersion(sacn_standard_version_t version);
@@ -247,7 +247,7 @@ inline bool Receiver::Settings::IsValid() const
  *
  * @param[in] settings Configuration parameters for the sACN receiver and this class instance.
  * @param[in] notify_handler The notification interface to call back to the application.
- * @param[in, out] ifaces Optional. If !empty, this is the list of interfaces the application wants to use, and the
+ * @param[in, out] netints Optional. If !empty, this is the list of interfaces the application wants to use, and the
  * operation_succeeded flags are filled in.  If empty, all available interfaces are tried and this vector isn't modified.
  * @return #kEtcPalErrOk: Receiver created successfully.
  * @return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.
@@ -259,14 +259,14 @@ inline bool Receiver::Settings::IsValid() const
  * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
 inline etcpal::Error Receiver::Startup(const Settings& settings, NotifyHandler& notify_handler,
-                                       std::vector<SacnMcastInterfaceToUse>& ifaces)
+                                       std::vector<SacnMcastInterface>& netints)
 {
   SacnReceiverConfig config = TranslateConfig(settings, notify_handler);
 
-  if (ifaces.empty())
+  if (netints.empty())
     return sacn_receiver_create(&config, &handle_, NULL, 0);
 
-  return sacn_receiver_create(&config, &handle_, ifaces.data(), ifaces.size());
+  return sacn_receiver_create(&config, &handle_, netints.data(), netints.size());
 }
 
 /**
@@ -328,7 +328,7 @@ inline etcpal::Error Receiver::ChangeUniverse(uint16_t new_universe_id)
  * Note that the networking reset is considered successful if it is able to successfully use any of the
  * network interfaces passed in.  This will only return #kEtcPalErrNoNetints if none of the interfaces work.
  *
- * @param[in, out] ifaces Optional. If !empty, this is the list of interfaces the application wants to use, and the
+ * @param[in, out] netints Optional. If !empty, this is the list of interfaces the application wants to use, and the
  * operation_succeeded flags are filled in.  If empty, all available interfaces are tried and this vector isn't modified.
  * @return #kEtcPalErrOk: Universe changed successfully.
  * @return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.
@@ -337,12 +337,12 @@ inline etcpal::Error Receiver::ChangeUniverse(uint16_t new_universe_id)
  * @return #kEtcPalErrNotFound: Handle does not correspond to a valid receiver.
  * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
-inline etcpal::Error Receiver::ResetNetworking(std::vector<SacnMcastInterfaceToUse>& ifaces)
+inline etcpal::Error Receiver::ResetNetworking(std::vector<SacnMcastInterface>& netints)
 {
-  if (ifaces.empty())
+  if (netints.empty())
     return sacn_receiver_reset_networking(handle_, nullptr, 0);
   else
-    return sacn_receiver_reset_networking(handle_, ifaces.data(), ifaces.size());
+    return sacn_receiver_reset_networking(handle_, netints.data(), netints.size());
 }
 
 /**

--- a/include/sacn/cpp/receiver.h
+++ b/include/sacn/cpp/receiver.h
@@ -20,85 +20,104 @@
 #ifndef SACN_CPP_RECEIVER_H_
 #define SACN_CPP_RECEIVER_H_
 
-/// @file sacn/cpp/receiver.h
-/// @brief C++ wrapper for the sACN Receiver API
+/**
+ * @file sacn/cpp/receiver.h
+ * @brief C++ wrapper for the sACN Receiver API
+ */
 
 #include "sacn/receiver.h"
 #include "etcpal/cpp/inet.h"
 
-/// @defgroup sacn_receiver_cpp sACN Receiver API
-/// @ingroup sacn_cpp_api
-/// @brief A C++ wrapper for the sACN Receiver API
+/**
+* @defgroup sacn_receiver_cpp sACN Receiver API
+* @ingroup sacn_cpp_api
+* @brief A C++ wrapper for the sACN Receiver API
+*/
 
 namespace sacn
 {
-/// @ingroup sacn_receiver_cpp
-/// @brief An instance of sACN Receiver functionality.
-///
-/// CHRISTIAN TODO: FILL OUT THIS COMMENT MORE -- DO WE NEED A using_receiver.md???
+/**
+ *@ingroup sacn_receiver_cpp
+ *@brief An instance of sACN Receiver functionality.
+ */
+// CHRISTIAN TODO: FILL OUT THIS COMMENT MORE -- DO WE NEED A using_receiver.md???
 class Receiver
 {
 public:
-  /// A handle type used by the sACN library to identify receiver instances.
+  /** A handle type used by the sACN library to identify receiver instances. */
   using Handle = sacn_receiver_t;
-  /// An invalid Handle value.
+  /** An invalid Handle value. */
   static constexpr Handle kInvalidHandle = SACN_RECEIVER_INVALID;
 
-  /// @ingroup sacn_receiver_cpp
-  /// @brief A base class for a class that receives notification callbacks from a sACN receiver.
+  /**
+  * @ingroup sacn_receiver_cpp
+  * @brief A base class for a class that receives notification callbacks from a sACN receiver.
+  */
   class NotifyHandler
   {
   public:
     virtual ~NotifyHandler() = default;
 
-    /// @brief Notify that one or more sources have been found.
-    /// @param universe The universe this receiver is monitoring.
-    /// @param found_sources Array of structs describing the source or sources that have been found with their current
-    /// values.
-    /// @param] num_sources_found Size of the found_sources array.
+    /**
+    * @brief Notify that one or more sources have been found.
+    * @param universe The universe this receiver is monitoring.
+    * @param found_sources Array of structs describing the source or sources that have been found with their current
+    * values.
+    * @param num_sources_found Size of the found_sources array.
+    */
     virtual void HandleSourcesFound(uint16_t universe, const SacnFoundSource* found_sources,
                                     size_t num_found_sources) = 0;
 
-    /// @brief Notify that a data packet has been received.
-    /// @param universe The universe this receiver is monitoring.
-    /// @param source_addr IP address & port of the packet source.
-    /// @param header The sACN header data.
-    /// @param pdata The DMX data.  Use header.slot_count to determine the length of this array.
+    /**
+    * @brief Notify that a data packet has been received.
+    * @param universe The universe this receiver is monitoring.
+    * @param source_addr IP address & port of the packet source.
+    * @param header The sACN header data.
+    * @param pdata The DMX data.  Use header.slot_count to determine the length of this array.
+    */
     virtual void HandleUniverseData(uint16_t universe, const etcpal::SockAddr& source_addr,
                                     const SacnHeaderData& header, const uint8_t* pdata) = 0;
 
-    /// @brief Notify that one or more sources have entered a data loss state.
-    /// @param universe The universe this receiver is monitoring.
-    /// @param lost_sources Array of structs describing the source or sources that have been lost.
-    /// @param num_lost_sources Size of the lost_sources array.
+    /**
+     * @brief Notify that one or more sources have entered a data loss state.
+     * @param universe The universe this receiver is monitoring.
+     * @param lost_sources Array of structs describing the source or sources that have been lost.
+     * @param num_lost_sources Size of the lost_sources array.
+     */
     virtual void HandleSourcesLost(uint16_t universe, const SacnLostSource* lost_sources, size_t num_lost_sources) = 0;
 
-    /// @brief Notify that a source has stopped transmission of per-address priority packets.
-    /// @param universe The universe this receiver is monitoring.
-    /// @param source Information about the source that has stopped transmission of per-address priority.
+    /**
+     * @brief Notify that a source has stopped transmission of per-address priority packets.
+     * @param universe The universe this receiver is monitoring.
+     * @param source Information about the source that has stopped transmission of per-address priority.
+     */
     virtual void HandleSourcePapLost(uint16_t universe, const SacnRemoteSource& source) = 0;
 
-    /// @brief Notify that more than the configured maximum number of sources are currently sending on the universe
-    /// being listened to.
-    /// @param universe The universe this receiver is monitoring.
+    /**
+     * @brief Notify that more than the configured maximum number of sources are currently sending on the universe
+     * being listened to.
+     * @param universe The universe this receiver is monitoring.
+     */
     virtual void HandleSourceLimitExceeded(uint16_t universe) = 0;
   };
 
-  /// @ingroup sacn_receiver_cpp
-  /// @brief A set of configuration settings that a receiver needs to initialize.
+  /**
+   * @ingroup sacn_receiver_cpp
+   * @brief A set of configuration settings that a receiver needs to initialize.
+   */
   struct Settings
   {
     /********* Required values **********/
 
-    uint16_t universe_id{0};  ///< The sACN universe number the receiver is listening to.
+    uint16_t universe_id{0};  /**< The sACN universe number the receiver is listening to. */
 
     /********* Optional values **********/
 
-    size_t source_count_max{SACN_RECEIVER_INFINITE_SOURCES};  ///< The maximum number of sources this universe will
-                                                              ///< listen to when using dynamic memory.
-    unsigned int flags{0};                   ///< A set of option flags. See the C API's "sACN receiver flags".
+    size_t source_count_max{SACN_RECEIVER_INFINITE_SOURCES}; /**< The maximum number of sources this universe will
+                                                                listen to when using dynamic memory. */
+    unsigned int flags{0};                   /**< A set of option flags. See the C API's "sACN receiver flags". */
 
-    /// Create an empty, invalid data structure by default.
+    /** Create an empty, invalid data structure by default. */
     Settings() = default;
     Settings(uint16_t new_universe_id);
 
@@ -108,8 +127,8 @@ public:
   Receiver() = default;
   Receiver(const Receiver& other) = delete;
   Receiver& operator=(const Receiver& other) = delete;
-  Receiver(Receiver&& other) = default;             ///< Move a device instance.
-  Receiver& operator=(Receiver&& other) = default;  ///< Move a device instance.
+  Receiver(Receiver&& other) = default;             /**< Move a device instance. */
+  Receiver& operator=(Receiver&& other) = default;  /**< Move a device instance. */
 
   etcpal::Error Startup(const Settings& settings, NotifyHandler& notify_handler,
                         std::vector<SacnMcastInterfaceToUse>& ifaces);
@@ -132,8 +151,10 @@ private:
   Handle handle_{kInvalidHandle};
 };
 
-/// @cond device_c_callbacks
-/// Callbacks from underlying device library to be forwarded
+/**
+ * @cond device_c_callbacks
+ * Callbacks from underlying device library to be forwarded
+ */
 namespace internal
 {
 extern "C" inline void ReceiverCbSourcesFound(sacn_receiver_t handle, uint16_t universe,
@@ -194,23 +215,29 @@ extern "C" inline void ReceiverCbSourceLimitExceeded(sacn_receiver_t handle, uin
 
 };  // namespace internal
 
-/// @endcond
+/**
+ * @endcond
+ */
 
-/// @brief Create a Receiver Settings instance by passing the required members explicitly.
-///
-/// Optional members can be modified directly in the struct.
+/**
+ * @brief Create a Receiver Settings instance by passing the required members explicitly.
+ *
+ * Optional members can be modified directly in the struct.
+ */
 inline Receiver::Settings::Settings(uint16_t new_universe_id) : universe_id(new_universe_id)
 {
 }
 
-/// Determine whether a Reciever Settings instance contains valid data for sACN operation.
+/**
+ * Determine whether a Reciever Settings instance contains valid data for sACN operation.
+ */
 inline bool Receiver::Settings::IsValid() const
 {
   return (universe_id > 0);
 }
 
-/*!
- * \brief Start listening for sACN data on a universe.
+/**
+ * @brief Start listening for sACN data on a universe.
  *
  * An sACN receiver can listen on one universe at a time, and each universe can only be listened to
  * by one receiver at at time.
@@ -218,18 +245,18 @@ inline bool Receiver::Settings::IsValid() const
  * Note that a receiver is considered as successfully created if it is able to successfully use any of the
  * network interfaces passed in.  This will only return #kEtcPalErrNoNetints if none of the interfaces work.
  *
- * \param[in] settings Configuration parameters for the sACN receiver and this class instance.
- * \param[in] notify_handler The notification interface to call back to the application.
- * \param[in, out] ifaces Optional. If !empty, this is the list of interfaces the application wants to use, and the
+ * @param[in] settings Configuration parameters for the sACN receiver and this class instance.
+ * @param[in] notify_handler The notification interface to call back to the application.
+ * @param[in, out] ifaces Optional. If !empty, this is the list of interfaces the application wants to use, and the
  * operation_succeeded flags are filled in.  If empty, all available interfaces are tried and this vector isn't modified.
- * \return #kEtcPalErrOk: Receiver created successfully.
- * \return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.
- * \return #kEtcPalErrInvalid: Invalid parameter provided.
- * \return #kEtcPalErrNotInit: Module not initialized.
- * \return #kEtcPalErrExists: A receiver already exists which is listening on the specified universe.
- * \return #kEtcPalErrNoMem: No room to allocate memory for this receiver.
- * \return #kEtcPalErrNotFound: A network interface ID given was not found on the system.
- * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ * @return #kEtcPalErrOk: Receiver created successfully.
+ * @return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.
+ * @return #kEtcPalErrInvalid: Invalid parameter provided.
+ * @return #kEtcPalErrNotInit: Module not initialized.
+ * @return #kEtcPalErrExists: A receiver already exists which is listening on the specified universe.
+ * @return #kEtcPalErrNoMem: No room to allocate memory for this receiver.
+ * @return #kEtcPalErrNotFound: A network interface ID given was not found on the system.
+ * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
 inline etcpal::Error Receiver::Startup(const Settings& settings, NotifyHandler& notify_handler,
                                        std::vector<SacnMcastInterfaceToUse>& ifaces)
@@ -242,8 +269,8 @@ inline etcpal::Error Receiver::Startup(const Settings& settings, NotifyHandler& 
   return sacn_receiver_create(&config, &handle_, ifaces.data(), ifaces.size());
 }
 
-/*!
- * \brief Stop listening for sACN data on a universe.
+/**
+ * @brief Stop listening for sACN data on a universe.
  *
  * Tears down the receiver and any sources currently being tracked on the receiver's universe.
  * Stops listening for sACN on that universe.
@@ -254,10 +281,10 @@ inline void Receiver::Shutdown()
   handle_ = kInvalidHandle;
 }
 
-/*!
- * \brief Get the universe this class is listening to.
+/**
+ * @brief Get the universe this class is listening to.
  *
- * \return If valid, the value is the universe id.  Otherwise, this is the underlying error the C library call returned.
+ * @return If valid, the value is the universe id.  Otherwise, this is the underlying error the C library call returned.
  */
 etcpal::Expected<uint16_t> Receiver::GetUniverse() const
 {
@@ -269,28 +296,28 @@ etcpal::Expected<uint16_t> Receiver::GetUniverse() const
     return err;
 }
 
-/*!
- * \brief Change the universe this class is listening to.
+/**
+ * @brief Change the universe this class is listening to.
  *
  * An sACN receiver can only listen on one universe at a time. After this call completes successfully, the receiver is
  * in a sampling period for the new universe and will provide HandleSourcesFound() calls when appropriate.
  * If this call fails, the caller must call Shutdown() on this class, because it may be in an invalid state.
  *
- * \param[in] new_universe_id New universe number that this receiver should listen to.
- * \return #kEtcPalErrOk: Universe changed successfully.
- * \return #kEtcPalErrInvalid: Invalid parameter provided.
- * \return #kEtcPalErrNotInit: Module not initialized.
- * \return #kEtcPalErrExists: A receiver already exists which is listening on the specified new universe.
- * \return #kEtcPalErrNotFound: Handle does not correspond to a valid receiver.
- * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ * @param[in] new_universe_id New universe number that this receiver should listen to.
+ * @return #kEtcPalErrOk: Universe changed successfully.
+ * @return #kEtcPalErrInvalid: Invalid parameter provided.
+ * @return #kEtcPalErrNotInit: Module not initialized.
+ * @return #kEtcPalErrExists: A receiver already exists which is listening on the specified new universe.
+ * @return #kEtcPalErrNotFound: Handle does not correspond to a valid receiver.
+ * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
 inline etcpal::Error Receiver::ChangeUniverse(uint16_t new_universe_id)
 {
   return sacn_receiver_change_universe(handle_, new_universe_id);
 }
 
-/*!
- * \brief Resets the underlying network sockets and packet receipt state for this class..
+/**
+ * @brief Resets the underlying network sockets and packet receipt state for this class..
  *
  * This is typically used when the application detects that the list of networking interfaces has changed.
  *
@@ -301,14 +328,14 @@ inline etcpal::Error Receiver::ChangeUniverse(uint16_t new_universe_id)
  * Note that the networking reset is considered successful if it is able to successfully use any of the
  * network interfaces passed in.  This will only return #kEtcPalErrNoNetints if none of the interfaces work.
  *
- * \param[in, out] ifaces Optional. If !empty, this is the list of interfaces the application wants to use, and the
+ * @param[in, out] ifaces Optional. If !empty, this is the list of interfaces the application wants to use, and the
  * operation_succeeded flags are filled in.  If empty, all available interfaces are tried and this vector isn't modified.
- * \return #kEtcPalErrOk: Universe changed successfully.
- * \return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.
- * \return #kEtcPalErrInvalid: Invalid parameter provided.
- * \return #kEtcPalErrNotInit: Module not initialized.
- * \return #kEtcPalErrNotFound: Handle does not correspond to a valid receiver.
- * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ * @return #kEtcPalErrOk: Universe changed successfully.
+ * @return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.
+ * @return #kEtcPalErrInvalid: Invalid parameter provided.
+ * @return #kEtcPalErrNotInit: Module not initialized.
+ * @return #kEtcPalErrNotFound: Handle does not correspond to a valid receiver.
+ * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
 inline etcpal::Error Receiver::ResetNetworking(std::vector<SacnMcastInterfaceToUse>& ifaces)
 {
@@ -318,24 +345,24 @@ inline etcpal::Error Receiver::ResetNetworking(std::vector<SacnMcastInterfaceToU
     return sacn_receiver_reset_networking(handle_, ifaces.data(), ifaces.size());
 }
 
-/*!
- * \brief Set the current version of the sACN standard to which the module is listening.
+/**
+ * @brief Set the current version of the sACN standard to which the module is listening.
  *
  * This is a global option across all listening receivers.
  *
- * \param[in] version Version of sACN to listen to.
+ * @param[in] version Version of sACN to listen to.
  */
 inline void Receiver::SetStandardVersion(sacn_standard_version_t version)
 {
   sacn_receiver_set_standard_version(version);
 }
 
-/*!
- * \brief Get the current version of the sACN standard to which the module is listening.
+/**
+ * @brief Get the current version of the sACN standard to which the module is listening.
  *
  * This is a global option across all listening receivers.
  *
- * \return Version of sACN to which the module is listening, or #kSacnStandardVersionNone if the module is
+ * @return Version of sACN to which the module is listening, or #kSacnStandardVersionNone if the module is
  *         not initialized.
  */
 inline sacn_standard_version_t Receiver::GetStandardVersion()
@@ -343,38 +370,38 @@ inline sacn_standard_version_t Receiver::GetStandardVersion()
   sacn_receiver_get_standard_version();
 }
 
-/*!
- * \brief Set the expired notification wait time.
+/**
+ * @brief Set the expired notification wait time.
  *
  * The library will wait at least this long after a data loss condition has been encountered before
  * calling HandleSourcesLost(). However, the wait may be longer due to the data loss algorithm (see \ref
  * data_loss_behavior).
  *
- * \param[in] wait_ms Wait time in milliseconds.
+ * @param[in] wait_ms Wait time in milliseconds.
  */
 inline void Receiver::SetExpiredWait(uint32_t wait_ms)
 {
   sacn_receiver_set_expired_wait(wait_ms);
 }
 
-/*!
- * \brief Get the current value of the expired notification wait time.
+/**
+ * @brief Get the current value of the expired notification wait time.
  *
  * The library will wait at least this long after a data loss condition has been encountered before
  * calling HandleSourcesLost(). However, the wait may be longer due to the data loss algorithm (see \ref
  * data_loss_behavior).
  *
- * \return Wait time in milliseconds.
+ * @return Wait time in milliseconds.
  */
 inline uint32_t Receiver::GetExpiredWait()
 {
   return sacn_receiver_get_expired_wait();
 }
 
-/*!
- * \brief Get the current handle to the underlying C sacn_receiver.
+/**
+ * @brief Get the current handle to the underlying C sacn_receiver.
  *
- * \return The handle or Receiver::kInvalidHandle.
+ * @return The handle or Receiver::kInvalidHandle.
  */
 inline constexpr Receiver::Handle Receiver::handle() const
 {

--- a/include/sacn/cpp/source.h
+++ b/include/sacn/cpp/source.h
@@ -87,7 +87,7 @@ public:
   Source(Source&& other) = default;             /**< Move a source instance. */
   Source& operator=(Source&& other) = default;  /**< Move a source instance. */
 
-  etcpal::Error Startup(const Settings& settings, std::vector<SacnMcastInterfaceToUse>& ifaces);
+  etcpal::Error Startup(const Settings& settings, std::vector<SacnMcastInterface>& netints);
   void Shutdown();
 
   etcpal::Error ChangeName(const std::string& new_name);
@@ -109,7 +109,7 @@ public:
   void SetListDirty(const std::vector<uint16_t>& universes);
   void SetDirtyAndForceSync(uint16_t universe);
 
-  etcpal::Error ResetNetworking(std::vector<SacnMcastInterfaceToUse>& ifaces);
+  etcpal::Error ResetNetworking(std::vector<SacnMcastInterface>& netints);
 
   constexpr Handle handle() const;
 
@@ -149,7 +149,7 @@ inline bool Source::Settings::IsValid() const
  * if none of the interfaces work.
  *
  * @param[in] settings Configuration parameters for the sACN source to be created.
- * @param[in, out] ifaces Optional. If !empty, this is the list of interfaces the application wants to use, and the
+ * @param[in, out] netints Optional. If !empty, this is the list of interfaces the application wants to use, and the
  * operation_succeeded flags are filled in.  If empty, all available interfaces are tried and this vector isn't modified.
  * @return #kEtcPalErrOk: Source successfully created.
  * @return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.
@@ -159,14 +159,14 @@ inline bool Source::Settings::IsValid() const
  * @return #kEtcPalErrNotFound: A network interface ID given was not found on the system.
  * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
-inline etcpal::Error Source::Startup(const Settings& settings, std::vector<SacnMcastInterfaceToUse>& ifaces)
+inline etcpal::Error Source::Startup(const Settings& settings, std::vector<SacnMcastInterface>& netints)
 {
   SacnSourceConfig config = TranslateConfig(settings);
 
-  if (ifaces.empty())
+  if (netints.empty())
     return sacn_source_create(&config, &handle_, NULL, 0);
 
-  return sacn_source_create(&config, &handle_, ifaces.data(), ifaces.size());
+  return sacn_source_create(&config, &handle_, netints.data(), netints.size());
 }
 
 /**
@@ -454,7 +454,7 @@ inline size_t Source::ProcessSources()
  * Note that the networking reset is considered successful if it is able to successfully use any of the
  * network interfaces passed in.  This will only return #kEtcPalErrNoNetints if none of the interfaces work.
  *
- * @param[in, out] ifaces Optional. If !empty, this is the list of interfaces the application wants to use, and the
+ * @param[in, out] netints Optional. If !empty, this is the list of interfaces the application wants to use, and the
  * operation_succeeded flags are filled in.  If empty, all available interfaces are tried and this vector isn't modified.
  * @return #kEtcPalErrOk: Source changed successfully.
  * @return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.
@@ -463,12 +463,12 @@ inline size_t Source::ProcessSources()
  * @return #kEtcPalErrNotFound: Handle does not correspond to a valid source.
  * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
-inline etcpal::Error Source::ResetNetworking(std::vector<SacnMcastInterfaceToUse>& ifaces)
+inline etcpal::Error Source::ResetNetworking(std::vector<SacnMcastInterface>& netints)
 {
-  if (ifaces.empty())
+  if (netints.empty())
     return sacn_source_reset_networking(handle_, nullptr, 0);
 
-  return sacn_source_reset_networking(handle_, ifaces.data(), ifaces.size());
+  return sacn_source_reset_networking(handle_, netints.data(), netints.size());
 }
 
 /**

--- a/include/sacn/cpp/source.h
+++ b/include/sacn/cpp/source.h
@@ -165,7 +165,7 @@ inline etcpal::Error Source::Startup(const Settings& settings, SacnNetworkChange
  * on a call to ProcessSources() after an additional three packets have been sent with the
  * "Stream_Terminated" option set. The source will also stop transmitting sACN universe discovery packets.
  *
- * Even though the destruction is queued, after this call the library will no longer use the priority_buffer
+ * Even though the destruction is queued, after this call the library will no longer use the priorities_buffer
  * or values_buffer you passed in on your call to AddUniverse().
  */
 inline void Source::Shutdown()
@@ -227,7 +227,7 @@ inline etcpal::Error Source::AddUniverse(const SacnSourceUniverseConfig& config,
  *
  * The source will also stop transmitting sACN universe discovery packets for that universe.
  *
- * Even though the destruction is queued, after this call the library will no longer use the priority_buffer
+ * Even though the destruction is queued, after this call the library will no longer use the priorities_buffer
  * or values_buffer you passed in on your call to AddUniverse().
  *
  * \param[in] universe Universe to remove.
@@ -393,7 +393,7 @@ inline void Source::SetListDirty(const std::vector<uint16_t>& universes)
 }
 
 /*!
- * \brief Like sacn_source_set_dirty, but also sets the force_sync flag on the packet.
+ * \brief Like Source::SetDirty, but also sets the force_sync flag on the packet.
  *
  * This function indicates that the data in the buffer for this source and universe has changed,
  * and should be sent on the next call to ProcessSources().  Additionally, the packet
@@ -417,12 +417,12 @@ inline void Source::SetDirtyAndForceSync(uint16_t universe)
  * called by an internal thread of the module. Otherwise, this must be called at the maximum rate
  * at which the application will send sACN.
  *
- * Sends data for universes which have been marked dirty, and sends keep-alive data for universes which are
+ * Sends data for universes which have been marked dirty, and sends keep-alive data for universes which 
  * haven't changed. Also destroys sources & universes that have been marked for termination after sending the required
  * three terminated packets.
  *
  * \return Current number of sources tracked by the library. This can be useful on shutdown to
- *         track when destroyed sources have finished sending the terminated packets and actually
+ *         track when destroyed sources have finished sending the terminated packets and have actually
  *         been destroyed.
  */
 inline size_t Source::ProcessSources()
@@ -443,7 +443,7 @@ inline size_t Source::ProcessSources()
  * Note that the networking reset is considered successful if it is able to successfully use any of the
  * network interfaces passed in.  This will only return #kEtcPalErrNoNetints if none of the interfaces work.
  *
- * \param[in] netints Optional array of network interfaces on which to send to the specified universe. If empty,
+ * \param[in] netints Optional array of network interfaces on which to send to the specified universe(s). If empty,
  *  all available network interfaces will be used.
  * \param[out] good_interfaces Optional. If non-NULL, good_interfaces is filled in with the list of network
  * interfaces that were succesfully used.
@@ -451,7 +451,7 @@ inline size_t Source::ProcessSources()
  * \return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.
  * \return #kEtcPalErrInvalid: Invalid parameter provided.
  * \return #kEtcPalErrNotInit: Module not initialized.
- * \return #kEtcPalErrNotFound: Handle does not correspond to a valid receiver.
+ * \return #kEtcPalErrNotFound: Handle does not correspond to a valid source.
  * \return #kEtcPalErrSys: An internal library or system call error occurred.
  */
 inline etcpal::Error Source::ResetNetworking(const std::vector<SacnMcastNetintId>& netints,

--- a/include/sacn/cpp/source.h
+++ b/include/sacn/cpp/source.h
@@ -1,0 +1,289 @@
+/******************************************************************************
+ * Copyright 2020 ETC Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************
+ * This file is a part of sACN. For more information, go to:
+ * https://github.com/ETCLabs/sACN
+ *****************************************************************************/
+
+#ifndef SACN_CPP_SOURCE_H_
+#define SACN_CPP_SOURCE_H_
+
+/// @file sacn/cpp/source.h
+/// @brief C++ wrapper for the sACN Source API
+
+#include "sacn/source.h"
+#include "etcpal/cpp/uuid.h"
+#include "etcpal/cpp/inet.h"
+
+/// @defgroup sacn_source_cpp sACN Source API
+/// @ingroup sacn_cpp_api
+/// @brief A C++ wrapper for the sACN Source API
+
+namespace sacn
+{
+/// @ingroup sacn_source_cpp
+/// @brief An instance of sACN Source functionality.
+///
+/// CHRISTIAN TODO: FILL OUT THIS COMMENT MORE -- DO WE NEED A using_source.md???
+class Source
+{
+public:
+  /// A handle type used by the sACN library to identify source instances.
+  using Handle = sacn_source_t;
+  /// An invalid Handle value.
+  static constexpr Handle kInvalidHandle = SACN_SOURCE_INVALID;
+
+  /// @ingroup sacn_source_cpp
+  /// @brief A set of configuration settings that a source needs to initialize.
+  struct Settings
+  {
+  /********* Required values **********/
+
+  /*! The source's CID. */
+  Uuid cid;
+  /*! The source's name, a UTF-8 encoded string. Up to #SACN_SOURCE_NAME_MAX_LEN characters will be used. */
+  std::string name;
+
+  /********* Optional values **********/
+
+  /*! The maximum number of sources this universe will send to when using dynamic memory. */
+  size_t universe_count_max{SACN_SOURCE_INFINITE_UNIVERSES};
+
+  /*! If non-empty, the list of network interfaces to transmit on.  Otherwise, all available interfaces are used. */
+  std::vector<SacnMcastNetintId> netints;
+
+  /*! If false (default), this module starts a thread that calls sacn_source_process_sources() every 23 ms.
+      If true, no thread is started and the application must call sacn_source_process_sources() at its DMX rate,
+      usually 23 ms. */
+  bool manually_process_source;
+
+    /// Create an empty, invalid data structure by default.
+    Settings() = default;
+    Settings(const Uuid& new_cid, const std::string& new_name);
+
+    bool IsValid() const;
+  };
+
+  Source() = default;
+  Source(const Source& other) = delete;
+  Source& operator=(const Source& other) = delete;
+  Source(Source&& other) = default;             ///< Move a device instance.
+  Source& operator=(Source&& other) = default;  ///< Move a device instance.
+
+  etcpal::Error Startup(const Settings& settings, SacnNetworkChangeResult* good_interfaces = nullptr);
+  void Shutdown();
+
+  etcpal::Error ChangeName(const std::string& new_name);
+
+  etcpal::Error AddUniverse(const SacnSourceUniverseConfig& config, bool dirty_now);
+  void RemoveUniverse(uint16_t universe);
+  etcpal::Error AddUnicastDestination(uint16_t universe, const etcpal::IpAddr& dest, bool dirty_now);
+  void RemoveUnicastDestination(uint16_t universe, const etcpal::IpAddr& dest);
+
+  etcpal::Expected<uint16_t> GetUniverse() const;
+  etcpal::Error ChangeUniverse(uint16_t new_universe_id);
+  etcpal::Error ResetNetworking(const std::vector<SacnMcastNetintId>& netints,
+                                SacnNetworkChangeResult* good_interfaces = nullptr);
+
+
+etcpal_error_t sacn_source_change_priority(sacn_source_t handle, uint16_t universe, uint8_t new_priority);
+etcpal_error_t sacn_source_change_preview_flag(sacn_source_t handle, uint16_t universe, bool new_preview_flag);
+etcpal_error_t sacn_source_change_synchronization_universe(sacn_source_t handle, uint16_t universe,
+                                                           uint16_t new_sync_universe);
+
+etcpal_error_t sacn_source_send_now(sacn_source_t handle, uint16_t universe, uint8_t start_code, const uint8_t* buffer,
+                                    size_t buflen);
+etcpal_error_t sacn_source_send_synchronization(sacn_source_t handle, uint16_t universe);
+
+void sacn_source_set_dirty(sacn_source_t handle, uint8_t universe);
+void sacn_source_set_list_dirty(sacn_source_t handle, uint8_t* universes, size_t num_universes);
+void sacn_source_set_dirty_and_force_sync(sacn_source_t handle, uint8_t universe);
+
+size_t sacn_source_process_sources(void);
+
+etcpal_error_t sacn_source_reset_networking(sacn_source_t handle, const SacnMcastNetintId* netints, size_t num_netints, SacnNetworkChangeResult* good_interfaces);
+
+  constexpr Handle handle() const;
+
+private:
+  SacnSourceConfig TranslateConfig(const Settings& settings);
+
+  Handle handle_{kInvalidHandle};
+};
+
+/// @brief Create a Receiver Settings instance by passing the required members explicitly.
+///
+/// Optional members can be modified directly in the struct.
+inline Receiver::Settings::Settings(uint16_t new_universe_id) : universe_id(new_universe_id)
+{
+}
+
+/// Determine whether a Reciever Settings instance contains valid data for sACN operation.
+inline bool Receiver::Settings::IsValid() const
+{
+  return (universe_id > 0);
+}
+
+/*!
+ * \brief Start listening for sACN data on a universe.
+ *
+ * An sACN receiver can listen on one universe at a time, and each universe can only be listened to
+ * by one receiver at at time.
+ *
+ * Note that a receiver is considered as successfully created if it is able to successfully use any of the
+ * network interfaces listed in the passed in configuration.  This will only return #kEtcPalErrNoNetints
+ * if none of the interfaces work.
+ *
+ * \param[in] settings Configuration parameters for the sACN receiver and this class instance.
+ * \param[in] notify_handler The notification interface to call back to the application.
+ * \param[in, out] good_interfaces Optional. If non-nil, good_interfaces is filled in with the list of network
+ * interfaces that were succesfully used.
+ * \return #kEtcPalErrOk: Receiver created successfully.
+ * \return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.
+ * \return #kEtcPalErrInvalid: Invalid parameter provided.
+ * \return #kEtcPalErrNotInit: Module not initialized.
+ * \return #kEtcPalErrExists: A receiver already exists which is listening on the specified universe.
+ * \return #kEtcPalErrNoMem: No room to allocate memory for this receiver.
+ * \return #kEtcPalErrNotFound: A network interface ID given was not found on the system.
+ * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ */
+inline etcpal::Error Receiver::Startup(const Settings& settings, NotifyHandler& notify_handler,
+                                       SacnNetworkChangeResult* good_interfaces)
+{
+  SacnReceiverConfig config = TranslateConfig(settings, notify_handler);
+  return sacn_receiver_create(&config, &handle_, good_interfaces);
+}
+
+/*!
+ * \brief Stop listening for sACN data on a universe.
+ *
+ * Tears down the receiver and any sources currently being tracked on the receiver's universe.
+ * Stops listening for sACN on that universe.
+ */
+inline void Receiver::Shutdown()
+{
+  sacn_receiver_destroy(handle_);
+  handle_ = kInvalidHandle;
+}
+
+/*!
+ * \brief Get the universe this class is listening to.
+ *
+ * \return If valid, the value is the universe id.  Otherwise, this is the underlying error the C library call returned.
+ */
+etcpal::Expected<uint16_t> Receiver::GetUniverse() const
+{
+  uint16_t result = 0;
+  etcpal_error_t err = sacn_receiver_get_universe(handle_, &result);
+  if (err == kEtcPalErrOk)
+    return result;
+  else
+    return err;
+}
+
+/*!
+ * \brief Change the universe this class is listening to.
+ *
+ * An sACN receiver can only listen on one universe at a time. After this call completes successfully, the receiver is
+ * in a sampling period for the new universe and will provide HandleSourcesFound() calls when appropriate.
+ * If this call fails, the caller must call Shutdown() on this class, because it may be in an invalid state.
+ *
+ * \param[in] new_universe_id New universe number that this receiver should listen to.
+ * \return #kEtcPalErrOk: Universe changed successfully.
+ * \return #kEtcPalErrInvalid: Invalid parameter provided.
+ * \return #kEtcPalErrNotInit: Module not initialized.
+ * \return #kEtcPalErrExists: A receiver already exists which is listening on the specified new universe.
+ * \return #kEtcPalErrNotFound: Handle does not correspond to a valid receiver.
+ * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ */
+inline etcpal::Error Receiver::ChangeUniverse(uint16_t new_universe_id)
+{
+  return sacn_receiver_change_universe(handle_, new_universe_id);
+}
+
+/*!
+ * \brief Resets the underlying network sockets and packet receipt state for this class..
+ *
+ * This is typically used when the application detects that the list of networking interfaces has changed.
+ *
+ * After this call completes successfully, the receiver is in a sampling period for the new universe and will provide
+ * HandleSourcesFound() calls when appropriate.
+ * If this call fails, the caller must call Shutdown() on this class, because it may be in an invalid state.
+ *
+ * Note that the networking reset is considered successful if it is able to successfully use any of the
+ * network interfaces passed in.  This will only return #kEtcPalErrNoNetints if none of the interfaces work.
+ *
+ * \param[in] netints Vector of network interfaces on which to listen to the specified universe. If empty,
+ *  all available network interfaces will be used.
+ * \param[in, out] good_interfaces Optional. If non-nil, good_interfaces is filled in with the list of network
+ * interfaces that were succesfully used.
+ * \return #kEtcPalErrOk: Universe changed successfully.
+ * \return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.
+ * \return #kEtcPalErrInvalid: Invalid parameter provided.
+ * \return #kEtcPalErrNotInit: Module not initialized.
+ * \return #kEtcPalErrNotFound: Handle does not correspond to a valid receiver.
+ * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ */
+inline etcpal::Error Receiver::ResetNetworking(const std::vector<SacnMcastNetintId>& netints,
+                                               SacnNetworkChangeResult* good_interfaces)
+{
+  if (netints.empty())
+    return sacn_receiver_reset_networking(handle_, nullptr, 0, good_interfaces);
+  else
+    return sacn_receiver_reset_networking(handle_, netints.data(), netints.size(), good_interfaces);
+}
+
+/*!
+ * \brief Get the current handle to the underlying C sacn_source.
+ *
+ * \return The handle or Source::kInvalidHandle.
+ */
+inline constexpr Source::Handle Source::handle() const
+{
+  return handle_;
+}
+
+inline SacnSourceConfig Source::TranslateConfig(const Settings& settings, NotifyHandler& notify_handler)
+{
+  // clang-format off
+  SacnReceiverConfig config = {
+    settings.universe_id,
+    {
+      internal::ReceiverCbSourcesFound,
+      internal::ReceiverCbUniverseData,
+      internal::ReceiverCbSourcesLost,
+      internal::ReceiverCbPapLost,
+      internal::ReceiverCbSourceLimitExceeded,
+      &notify_handler
+    },
+    settings.source_count_max,
+    settings.flags,
+    nullptr, 
+    settings.netints.size()
+  };
+  // clang-format on
+
+  // Now initialize the netints
+  if (config.num_netints > 0)
+  {
+    config.netints = settings.netints.data();
+  }
+
+  return config;
+}
+
+};  // namespace sacn
+
+#endif  // SACN_CPP_SOURCE_H_

--- a/include/sacn/cpp/source.h
+++ b/include/sacn/cpp/source.h
@@ -142,7 +142,7 @@ inline bool Source::Settings::IsValid() const
  * if none of the interfaces work.
  *
  * \param[in] settings Configuration parameters for the sACN source to be created.
- * \param[in, out] good_interfaces Optional. If non-nil, good_interfaces is filled in with the list of network
+ * \param[out] good_interfaces Optional. If non-nil, good_interfaces is filled in with the list of network
  * interfaces that were succesfully used.
  * \return #kEtcPalErrOk: Source successfully created.
  * \return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.
@@ -445,7 +445,7 @@ inline size_t Source::ProcessSources()
  *
  * \param[in] netints Optional array of network interfaces on which to send to the specified universe. If empty,
  *  all available network interfaces will be used.
- * \param[in, out] good_interfaces Optional. If non-NULL, good_interfaces is filled in with the list of network
+ * \param[out] good_interfaces Optional. If non-NULL, good_interfaces is filled in with the list of network
  * interfaces that were succesfully used.
  * \return #kEtcPalErrOk: Source changed successfully.
  * \return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.

--- a/include/sacn/cpp/source.h
+++ b/include/sacn/cpp/source.h
@@ -101,10 +101,10 @@ public:
 
     /********* Optional values **********/
 
-    /** The sACN priority that is sent in each packet. This is only allowed to be from 0 - 200. Defaults to 100. */
+    /** The sACN universe priority that is sent in each packet. This is only allowed to be from 0 - 200. Defaults to 100. */
     uint8_t priority{100};
     /** The (optional) buffer of up to 512 per-address priorities that will be sent each tick.
-        If this is nil, only the priority will be used.
+        If this is nil, only the universe priority will be used.
         If non-nil, this buffer is evaluated each tick.  Changes to and from 0 ("don't care") cause appropriate
         sacn packets over time to take and give control of those DMX values as defined in the per-address priority
         specification.
@@ -161,7 +161,7 @@ public:
 
   constexpr Handle handle() const;
 
-  static size_t ProcessAll();
+  static int ProcessAll();
 
 private:
   SacnSourceConfig TranslateConfig(const Settings& settings);
@@ -505,7 +505,7 @@ inline void Source::SetDirtyAndForceSync(uint16_t universe)
  *         track when destroyed sources have finished sending the terminated packets and have actually
  *         been destroyed.
  */
-inline size_t Source::ProcessAll()
+inline int Source::ProcessAll()
 {
   return sacn_source_process_all();
 }

--- a/include/sacn/cpp/source.h
+++ b/include/sacn/cpp/source.h
@@ -80,8 +80,8 @@ public:
   Source() = default;
   Source(const Source& other) = delete;
   Source& operator=(const Source& other) = delete;
-  Source(Source&& other) = default;             ///< Move a device instance.
-  Source& operator=(Source&& other) = default;  ///< Move a device instance.
+  Source(Source&& other) = default;             ///< Move a source instance.
+  Source& operator=(Source&& other) = default;  ///< Move a source instance.
 
   etcpal::Error Startup(const Settings& settings, SacnNetworkChangeResult* good_interfaces = nullptr);
   void Shutdown();

--- a/include/sacn/cpp/source.h
+++ b/include/sacn/cpp/source.h
@@ -20,54 +20,61 @@
 #ifndef SACN_CPP_SOURCE_H_
 #define SACN_CPP_SOURCE_H_
 
-/// @file sacn/cpp/source.h
-/// @brief C++ wrapper for the sACN Source API
+/**
+ * @file sacn/cpp/source.h
+ * @brief C++ wrapper for the sACN Source API
+ */
 
 #include <cstring>
 #include "sacn/source.h"
 #include "etcpal/cpp/uuid.h"
 #include "etcpal/cpp/inet.h"
 
-/// @defgroup sacn_source_cpp sACN Source API
-/// @ingroup sacn_cpp_api
-/// @brief A C++ wrapper for the sACN Source API
+/**
+ * @defgroup sacn_source_cpp sACN Source API
+ * @ingroup sacn_cpp_api
+ * @brief A C++ wrapper for the sACN Source API
+ */
 
 namespace sacn
 {
-/// @ingroup sacn_source_cpp
-/// @brief An instance of sACN Source functionality.
-///
-/// CHRISTIAN TODO: FILL OUT THIS COMMENT MORE -- DO WE NEED A using_source.md???
+/**
+ * @ingroup sacn_source_cpp
+ * @brief An instance of sACN Source functionality.
+ */
+// CHRISTIAN TODO: FILL OUT THIS COMMENT MORE -- DO WE NEED A using_source.md???
 class Source
 {
 public:
-  /// A handle type used by the sACN library to identify source instances.
+  /** A handle type used by the sACN library to identify source instances. */
   using Handle = sacn_source_t;
-  /// An invalid Handle value.
+  /** An invalid Handle value. */
   static constexpr Handle kInvalidHandle = SACN_SOURCE_INVALID;
 
-  /// @ingroup sacn_source_cpp
-  /// @brief A set of configuration settings that a source needs to initialize.
+  /**
+   * @ingroup sacn_source_cpp
+   * @brief A set of configuration settings that a source needs to initialize.
+   */
   struct Settings
   {
     /********* Required values **********/
 
-    /*! The source's CID. */
+    /** The source's CID. */
     etcpal::Uuid cid;
-    /*! The source's name, a UTF-8 encoded string. Up to #SACN_SOURCE_NAME_MAX_LEN characters will be used. */
+    /** The source's name, a UTF-8 encoded string. Up to #SACN_SOURCE_NAME_MAX_LEN characters will be used. */
     std::string name;
 
     /********* Optional values **********/
 
-    /*! The maximum number of universes this source will send to when using dynamic memory. */
+    /** The maximum number of universes this source will send to when using dynamic memory. */
     size_t universe_count_max{SACN_SOURCE_INFINITE_UNIVERSES};
 
-    /*! If false (default), this module starts a thread that calls ProcessSources() every 23 ms.
+    /** If false (default), this module starts a thread that calls ProcessSources() every 23 ms.
         If true, no thread is started and the application must call ProcessSources() at its DMX rate,
         usually 23 ms. */
     bool manually_process_source{false};
 
-    /// Create an empty, invalid data structure by default.
+    /** Create an empty, invalid data structure by default. */
     Settings() = default;
     Settings(const etcpal::Uuid& new_cid, const std::string& new_name);
 
@@ -77,8 +84,8 @@ public:
   Source() = default;
   Source(const Source& other) = delete;
   Source& operator=(const Source& other) = delete;
-  Source(Source&& other) = default;             ///< Move a source instance.
-  Source& operator=(Source&& other) = default;  ///< Move a source instance.
+  Source(Source&& other) = default;             /**< Move a source instance. */
+  Source& operator=(Source&& other) = default;  /**< Move a source instance. */
 
   etcpal::Error Startup(const Settings& settings, std::vector<SacnMcastInterfaceToUse>& ifaces);
   void Shutdown();
@@ -114,22 +121,26 @@ private:
   Handle handle_{kInvalidHandle};
 };
 
-/// @brief Create a Source Settings instance by passing the required members explicitly.
-///
-/// Optional members can be modified directly in the struct.
+/**
+ * @brief Create a Source Settings instance by passing the required members explicitly.
+ *
+ * Optional members can be modified directly in the struct.
+ */
 inline Source::Settings::Settings(const etcpal::Uuid& new_cid, const std::string& new_name)
     : cid(new_cid), name(new_name)
 {
 }
 
-/// Determine whether a Source Settings instance contains valid data for sACN operation.
+/**
+ * Determine whether a Source Settings instance contains valid data for sACN operation.
+ */
 inline bool Source::Settings::IsValid() const
 {
   return !cid.IsNull();
 }
 
-/*!
- * \brief Create a new sACN source to send sACN data.
+/**
+ * @brief Create a new sACN source to send sACN data.
  *
  * This creates the instance of the source, but no data is sent until AddUniverse() and SetDirty() is called.
  *
@@ -137,16 +148,16 @@ inline bool Source::Settings::IsValid() const
  * network interfaces listed in the passed in configuration.  This will only return #kEtcPalErrNoNetints
  * if none of the interfaces work.
  *
- * \param[in] settings Configuration parameters for the sACN source to be created.
- * \param[in, out] ifaces Optional. If !empty, this is the list of interfaces the application wants to use, and the
+ * @param[in] settings Configuration parameters for the sACN source to be created.
+ * @param[in, out] ifaces Optional. If !empty, this is the list of interfaces the application wants to use, and the
  * operation_succeeded flags are filled in.  If empty, all available interfaces are tried and this vector isn't modified.
- * \return #kEtcPalErrOk: Source successfully created.
- * \return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.
- * \return #kEtcPalErrInvalid: Invalid parameter provided.
- * \return #kEtcPalErrNotInit: Module not initialized.
- * \return #kEtcPalErrNoMem: No room to allocate an additional source.
- * \return #kEtcPalErrNotFound: A network interface ID given was not found on the system.
- * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ * @return #kEtcPalErrOk: Source successfully created.
+ * @return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.
+ * @return #kEtcPalErrInvalid: Invalid parameter provided.
+ * @return #kEtcPalErrNotInit: Module not initialized.
+ * @return #kEtcPalErrNoMem: No room to allocate an additional source.
+ * @return #kEtcPalErrNotFound: A network interface ID given was not found on the system.
+ * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
 inline etcpal::Error Source::Startup(const Settings& settings, std::vector<SacnMcastInterfaceToUse>& ifaces)
 {
@@ -158,8 +169,8 @@ inline etcpal::Error Source::Startup(const Settings& settings, std::vector<SacnM
   return sacn_source_create(&config, &handle_, ifaces.data(), ifaces.size());
 }
 
-/*!
- * \brief Destroy an sACN source instance.
+/**
+ * @brief Destroy an sACN source instance.
  *
  * Stops sending all universes for this source. The destruction is queued, and actually occurs
  * on a call to ProcessSources() after an additional three packets have been sent with the
@@ -174,27 +185,27 @@ inline void Source::Shutdown()
   handle_ = kInvalidHandle;
 }
 
-/*!
- * \brief Change the name of an sACN source.
+/**
+ * @brief Change the name of an sACN source.
  *
  * The name is a UTF-8 string representing "a user-assigned name provided by the source of the
  * packet for use in displaying the identity of a source to a user." Only up to
  * #SACN_SOURCE_NAME_MAX_LEN characters will be used.
  *
- * \param[in] new_name New name to use for this universe.
- * \return #kEtcPalErrOk: Name set successfully.
- * \return #kEtcPalErrInvalid: Invalid parameter provided.
- * \return #kEtcPalErrNotInit: Module not initialized.
- * \return #kEtcPalErrNotFound: Handle does not correspond to a valid source.
- * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ * @param[in] new_name New name to use for this universe.
+ * @return #kEtcPalErrOk: Name set successfully.
+ * @return #kEtcPalErrInvalid: Invalid parameter provided.
+ * @return #kEtcPalErrNotInit: Module not initialized.
+ * @return #kEtcPalErrNotFound: Handle does not correspond to a valid source.
+ * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
 inline etcpal::Error Source::ChangeName(const std::string& new_name)
 {
   return sacn_source_change_name(handle_, new_name.c_str());
 }
 
-/*!
- * \brief Add a universe to an sACN source.
+/**
+ * @brief Add a universe to an sACN source.
  *
  * Adds a universe to a source.
  * After this call completes, the applicaton must call SetDirty() to mark it ready for processing.
@@ -202,22 +213,22 @@ inline etcpal::Error Source::ChangeName(const std::string& new_name)
  * If the source is not marked as unicast_only, the source will add the universe to its sACN Universe
  * Discovery packets.
 
- * \param[in] config Configuration parameters for the universe to be added.
- * \return #kEtcPalErrOk: Universe successfully added.
- * \return #kEtcPalErrInvalid: Invalid parameter provided.
- * \return #kEtcPalErrNotInit: Module not initialized.
- * \return #kEtcPalErrExists: Universe given was already added to this source.
- * \return #kEtcPalErrNotFound: Handle does not correspond to a valid source.
- * \return #kEtcPalErrNoMem: No room to allocate additional universe.
- * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ * @param[in] config Configuration parameters for the universe to be added.
+ * @return #kEtcPalErrOk: Universe successfully added.
+ * @return #kEtcPalErrInvalid: Invalid parameter provided.
+ * @return #kEtcPalErrNotInit: Module not initialized.
+ * @return #kEtcPalErrExists: Universe given was already added to this source.
+ * @return #kEtcPalErrNotFound: Handle does not correspond to a valid source.
+ * @return #kEtcPalErrNoMem: No room to allocate additional universe.
+ * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
 inline etcpal::Error Source::AddUniverse(const SacnSourceUniverseConfig& config)
 {
   return sacn_source_add_universe(handle_, &config);
 }
 
-/*!
- * \brief Remove a universe from a source.
+/**
+ * @brief Remove a universe from a source.
  *
  * This queues the source for removal. The destruction actually occurs
  * on a call to ProcessSources() after an additional three packets have been sent with the
@@ -228,172 +239,172 @@ inline etcpal::Error Source::AddUniverse(const SacnSourceUniverseConfig& config)
  * Even though the destruction is queued, after this call the library will no longer use the priorities_buffer
  * or values_buffer you passed in on your call to AddUniverse().
  *
- * \param[in] universe Universe to remove.
+ * @param[in] universe Universe to remove.
  */
 inline void Source::RemoveUniverse(uint16_t universe)
 {
   sacn_source_remove_universe(handle_, universe);
 }
 
-/*!
- * \brief Add a unicast destination for a source's universe.
+/**
+ * @brief Add a unicast destination for a source's universe.
  *
  * Adds a unicast destination for a source's universe.
  * After this call completes, the applicaton must call SetDirty() to mark it ready for processing.
 
- * \param[in] universe Universe to change.
- * \param[in] dest The destination IP.
- * \return #kEtcPalErrOk: Address added successfully.
- * \return #kEtcPalErrInvalid: Invalid parameter provided.
- * \return #kEtcPalErrNotInit: Module not initialized.
- * \return #kEtcPalErrNotFound: Handle does not correspond to a valid source or the universe is not on that source.
- * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ * @param[in] universe Universe to change.
+ * @param[in] dest The destination IP.
+ * @return #kEtcPalErrOk: Address added successfully.
+ * @return #kEtcPalErrInvalid: Invalid parameter provided.
+ * @return #kEtcPalErrNotInit: Module not initialized.
+ * @return #kEtcPalErrNotFound: Handle does not correspond to a valid source or the universe is not on that source.
+ * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
 inline etcpal::Error Source::AddUnicastDestination(uint16_t universe, const etcpal::IpAddr& dest)
 {
   return sacn_source_add_unicast_destination(handle_, universe, &dest.get());
 }
 
-/*!
- * \brief Remove a unicast destination on a source's universe.
+/**
+ * @brief Remove a unicast destination on a source's universe.
  *
  * This queues the address for removal. The removal actually occurs
  * on a call to ProcessSources() after an additional three packets have been sent with the
  * "Stream_Terminated" option set.
  *
- * \param[in] universe Universe to change.
- * \param[in] dest The destination IP.  Must match the address passed to AddUnicastDestination().
+ * @param[in] universe Universe to change.
+ * @param[in] dest The destination IP.  Must match the address passed to AddUnicastDestination().
  */
 inline void Source::RemoveUnicastDestination(uint16_t universe, const etcpal::IpAddr& dest)
 {
   sacn_source_remove_unicast_destination(handle_, universe, &dest.get());
 }
 
-/*!
- * \brief Change the priority of a universe on a sACN source.
+/**
+ * @brief Change the priority of a universe on a sACN source.
  *
- * \param[in] universe Universe to change.
- * \param[in] new_priority New priority of the data sent from this source. Valid range is 0 to 200,
+ * @param[in] universe Universe to change.
+ * @param[in] new_priority New priority of the data sent from this source. Valid range is 0 to 200,
  *                         inclusive.
- * \return #kEtcPalErrOk: Priority set successfully.
- * \return #kEtcPalErrInvalid: Invalid parameter provided.
- * \return #kEtcPalErrNotInit: Module not initialized.
- * \return #kEtcPalErrNotFound: Handle does not correspond to a valid source or the universe is not on that source.
- * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ * @return #kEtcPalErrOk: Priority set successfully.
+ * @return #kEtcPalErrInvalid: Invalid parameter provided.
+ * @return #kEtcPalErrNotInit: Module not initialized.
+ * @return #kEtcPalErrNotFound: Handle does not correspond to a valid source or the universe is not on that source.
+ * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
 inline etcpal::Error Source::ChangePriority(uint16_t universe, uint8_t new_priority)
 {
   return sacn_source_change_priority(handle_, universe, new_priority);
 }
 
-/*!
- * \brief Change the sending_preview option on a universe of a sACN source.
+/**
+ * @brief Change the sending_preview option on a universe of a sACN source.
  *
  * Sets the state of a flag in the outgoing sACN packets that indicates that the data is (from
  * E1.31) "intended for use in visualization or media server preview applications and shall not be
  * used to generate live output."
  *
- * \param[in] new_preview_flag The new sending_preview option.
- * \return #kEtcPalErrOk: sending_preview option set successfully.
- * \return #kEtcPalErrInvalid: Invalid parameter provided.
- * \return #kEtcPalErrNotInit: Module not initialized.
- * \return #kEtcPalErrNotFound: Handle does not correspond to a valid source or the universe is not on that source.
- * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ * @param[in] new_preview_flag The new sending_preview option.
+ * @return #kEtcPalErrOk: sending_preview option set successfully.
+ * @return #kEtcPalErrInvalid: Invalid parameter provided.
+ * @return #kEtcPalErrNotInit: Module not initialized.
+ * @return #kEtcPalErrNotFound: Handle does not correspond to a valid source or the universe is not on that source.
+ * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
 inline etcpal::Error Source::ChangePreviewFlag(uint16_t universe, bool new_preview_flag)
 {
   return sacn_source_change_preview_flag(handle_, universe, new_preview_flag);
 }
 
-/*!
- * \brief Changes the synchronize uinverse for a universe of a sACN source.
+/**
+ * @brief Changes the synchronize uinverse for a universe of a sACN source.
  *
  * This will change the synchronization universe used by a sACN universe on the source.
  * If this value is 0, synchronization is turned off for that universe.
  *
  * TODO: At this time, synchronization is not supported by this library.
  *
- * \param[in] universe The universe to change.
- * \param[in] new_sync_universe The new synchronization universe to set.
- * \return #kEtcPalErrOk: sync_universe set successfully.
- * \return #kEtcPalErrInvalid: Invalid parameter provided.
- * \return #kEtcPalErrNotInit: Module not initialized.
- * \return #kEtcPalErrNotFound: Handle does not correspond to a valid source or the universe is not on that source.
- * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ * @param[in] universe The universe to change.
+ * @param[in] new_sync_universe The new synchronization universe to set.
+ * @return #kEtcPalErrOk: sync_universe set successfully.
+ * @return #kEtcPalErrInvalid: Invalid parameter provided.
+ * @return #kEtcPalErrNotInit: Module not initialized.
+ * @return #kEtcPalErrNotFound: Handle does not correspond to a valid source or the universe is not on that source.
+ * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
 inline etcpal::Error Source::ChangeSynchronizationUniverse(uint16_t universe, uint16_t new_sync_universe)
 {
   return sacn_source_change_synchronization_universe(handle_, universe, new_sync_universe);
 }
 
-/*!
- * \brief Immediately sends the provided sACN start code & data.
+/**
+ * @brief Immediately sends the provided sACN start code & data.
  *
  * Immediately sends a sACN packet with the provided start code and data.
  * This function is intended for sACN packets that have a startcode other than 0 or 0xdd, since those
  * start codes are taken care of by ProcessSources().
  *
- * \param[in] universe Universe to send on.
- * \param[in] start_code The start code to send.
- * \param[in] buffer The buffer to send.  Must not be NULL.
- * \param[in] buflen The size of buffer.
- * \return #kEtcPalErrOk: Message successfully sent.
- * \return #kEtcPalErrInvalid: Invalid parameter provided.
- * \return #kEtcPalErrNotInit: Module not initialized.
- * \return #kEtcPalErrNotFound: Handle does not correspond to a valid source, or the universe was not found on this
+ * @param[in] universe Universe to send on.
+ * @param[in] start_code The start code to send.
+ * @param[in] buffer The buffer to send.  Must not be NULL.
+ * @param[in] buflen The size of buffer.
+ * @return #kEtcPalErrOk: Message successfully sent.
+ * @return #kEtcPalErrInvalid: Invalid parameter provided.
+ * @return #kEtcPalErrNotInit: Module not initialized.
+ * @return #kEtcPalErrNotFound: Handle does not correspond to a valid source, or the universe was not found on this
  *                              source.
- * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
 inline etcpal::Error Source::SendNow(uint16_t universe, uint8_t start_code, const uint8_t* buffer, size_t buflen)
 {
   return sacn_source_send_now(handle_, universe, start_code, buffer, buflen);
 }
 
-/*!
- * \brief Immediately sends a synchronization packet for the universe on a source.
+/**
+ * @brief Immediately sends a synchronization packet for the universe on a source.
  *
  * This will cause an immediate transmission of a synchronization packet for the source/universe.
  * If the universe does not have a synchronization universe configured, this call is ignored.
  *
  * TODO: At this time, synchronization is not supported by this library.
  *
- * \param[in] universe Universe to send on.
- * \return #kEtcPalErrOk: Message successfully sent.
- * \return #kEtcPalErrInvalid: Invalid parameter provided.
- * \return #kEtcPalErrNotInit: Module not initialized.
- * \return #kEtcPalErrNotFound: Handle does not correspond to a valid source, or the universe was not found on this
+ * @param[in] universe Universe to send on.
+ * @return #kEtcPalErrOk: Message successfully sent.
+ * @return #kEtcPalErrInvalid: Invalid parameter provided.
+ * @return #kEtcPalErrNotInit: Module not initialized.
+ * @return #kEtcPalErrNotFound: Handle does not correspond to a valid source, or the universe was not found on this
  *                              source.
- * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
 inline etcpal::Error Source::SendSynchronization(uint16_t universe)
 {
   return sacn_source_send_synchronization(handle_, universe);
 }
 
-/*!
- * \brief Indicate that the data in the buffer for this source and universe has changed and
+/**
+ * @brief Indicate that the data in the buffer for this source and universe has changed and
  *        should be sent on the next call to ProcessSources().
  *
- * \param[in] universe Universe to mark as dirty.
+ * @param[in] universe Universe to mark as dirty.
  */
 inline void Source::SetDirty(uint16_t universe)
 {
   sacn_source_set_dirty(handle_, universe);
 }
 
-/*!
- * \brief Indicate that the data in the buffers for a list of universes on a source  has
+/**
+ * @brief Indicate that the data in the buffers for a list of universes on a source  has
  *        changed and should be sent on the next call to ProcessSources().
  *
- * \param[in] universes Vector of universes to mark as dirty.
+ * @param[in] universes Vector of universes to mark as dirty.
  */
 inline void Source::SetListDirty(const std::vector<uint16_t>& universes)
 {
   sacn_source_set_list_dirty(handle_, universes.data(), universes.size());
 }
 
-/*!
- * \brief Like Source::SetDirty, but also sets the force_sync flag on the packet.
+/**
+ * @brief Like Source::SetDirty, but also sets the force_sync flag on the packet.
  *
  * This function indicates that the data in the buffer for this source and universe has changed,
  * and should be sent on the next call to ProcessSources().  Additionally, the packet
@@ -403,15 +414,15 @@ inline void Source::SetListDirty(const std::vector<uint16_t>& universes)
  *
  * TODO: At this time, synchronization is not supported by this library.
  *
- * \param[in] universe Universe to mark as dirty.
+ * @param[in] universe Universe to mark as dirty.
  */
 inline void Source::SetDirtyAndForceSync(uint16_t universe)
 {
   sacn_source_set_dirty_and_force_sync(handle_, universe);
 }
 
-/*!
- * \brief Process created sources and do the actual sending of sACN data on all universes.
+/**
+ * @brief Process created sources and do the actual sending of sACN data on all universes.
  *
  * Note: Unless you created the source with manually_process_source set to true, this will be automatically
  * called by an internal thread of the module. Otherwise, this must be called at the maximum rate
@@ -421,7 +432,7 @@ inline void Source::SetDirtyAndForceSync(uint16_t universe)
  * haven't changed. Also destroys sources & universes that have been marked for termination after sending the required
  * three terminated packets.
  *
- * \return Current number of sources tracked by the library. This can be useful on shutdown to
+ * @return Current number of sources tracked by the library. This can be useful on shutdown to
  *         track when destroyed sources have finished sending the terminated packets and have actually
  *         been destroyed.
  */
@@ -430,8 +441,8 @@ inline size_t Source::ProcessSources()
   return sacn_source_process_sources();
 }
 
-/*!
- * \brief Resets the underlying network sockets for the sACN source..
+/**
+ * @brief Resets the underlying network sockets for the sACN source..
  *
  * This is typically used when the application detects that the list of networking interfaces has changed.
  *
@@ -443,14 +454,14 @@ inline size_t Source::ProcessSources()
  * Note that the networking reset is considered successful if it is able to successfully use any of the
  * network interfaces passed in.  This will only return #kEtcPalErrNoNetints if none of the interfaces work.
  *
- * \param[in, out] ifaces Optional. If !empty, this is the list of interfaces the application wants to use, and the
+ * @param[in, out] ifaces Optional. If !empty, this is the list of interfaces the application wants to use, and the
  * operation_succeeded flags are filled in.  If empty, all available interfaces are tried and this vector isn't modified.
- * \return #kEtcPalErrOk: Source changed successfully.
- * \return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.
- * \return #kEtcPalErrInvalid: Invalid parameter provided.
- * \return #kEtcPalErrNotInit: Module not initialized.
- * \return #kEtcPalErrNotFound: Handle does not correspond to a valid source.
- * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ * @return #kEtcPalErrOk: Source changed successfully.
+ * @return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.
+ * @return #kEtcPalErrInvalid: Invalid parameter provided.
+ * @return #kEtcPalErrNotInit: Module not initialized.
+ * @return #kEtcPalErrNotFound: Handle does not correspond to a valid source.
+ * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
 inline etcpal::Error Source::ResetNetworking(std::vector<SacnMcastInterfaceToUse>& ifaces)
 {
@@ -460,10 +471,10 @@ inline etcpal::Error Source::ResetNetworking(std::vector<SacnMcastInterfaceToUse
   return sacn_source_reset_networking(handle_, ifaces.data(), ifaces.size());
 }
 
-/*!
- * \brief Get the current handle to the underlying C sacn_source.
+/**
+ * @brief Get the current handle to the underlying C sacn_source.
  *
- * \return The handle or Source::kInvalidHandle.
+ * @return The handle or Source::kInvalidHandle.
  */
 inline constexpr Source::Handle Source::handle() const
 {

--- a/include/sacn/cpp/source.h
+++ b/include/sacn/cpp/source.h
@@ -88,10 +88,10 @@ public:
 
   etcpal::Error ChangeName(const std::string& new_name);
 
-  etcpal::Error AddUniverse(const SacnSourceUniverseConfig& config, bool dirty_now);
+  etcpal::Error AddUniverse(const SacnSourceUniverseConfig& config);
   void RemoveUniverse(uint16_t universe);
 
-  etcpal::Error AddUnicastDestination(uint16_t universe, const etcpal::IpAddr& dest, bool dirty_now);
+  etcpal::Error AddUnicastDestination(uint16_t universe, const etcpal::IpAddr& dest);
   void RemoveUnicastDestination(uint16_t universe, const etcpal::IpAddr& dest);
 
   etcpal::Error ChangePriority(uint16_t universe, uint8_t new_priority);
@@ -196,15 +196,13 @@ inline etcpal::Error Source::ChangeName(const std::string& new_name)
 /*!
  * \brief Add a universe to an sACN source.
  *
- * Adds a universe to a source. If dirty_now is true, the source will start sending values on the
- * next call to ProcessSources(). If dirty_now is false, the applicaton must call SetDirty()
- * to mark it ready for processing.
+ * Adds a universe to a source.
+ * After this call completes, the applicaton must call SetDirty() to mark it ready for processing.
  *
  * If the source is not marked as unicast_only, the source will add the universe to its sACN Universe
  * Discovery packets.
 
  * \param[in] config Configuration parameters for the universe to be added.
- * \param[in] dirty_now Whether or not to immediately mark the universe as dirty.
  * \return #kEtcPalErrOk: Universe successfully added.
  * \return #kEtcPalErrInvalid: Invalid parameter provided.
  * \return #kEtcPalErrNotInit: Module not initialized.
@@ -213,9 +211,9 @@ inline etcpal::Error Source::ChangeName(const std::string& new_name)
  * \return #kEtcPalErrNoMem: No room to allocate additional universe.
  * \return #kEtcPalErrSys: An internal library or system call error occurred.
  */
-inline etcpal::Error Source::AddUniverse(const SacnSourceUniverseConfig& config, bool dirty_now)
+inline etcpal::Error Source::AddUniverse(const SacnSourceUniverseConfig& config)
 {
-  return sacn_source_add_universe(handle_, &config, dirty_now);
+  return sacn_source_add_universe(handle_, &config);
 }
 
 /*!
@@ -240,18 +238,20 @@ inline void Source::RemoveUniverse(uint16_t universe)
 /*!
  * \brief Add a unicast destination for a source's universe.
  *
+ * Adds a unicast destination for a source's universe.
+ * After this call completes, the applicaton must call SetDirty() to mark it ready for processing.
+
  * \param[in] universe Universe to change.
  * \param[in] dest The destination IP.
- * \param[in] dirty_now Whether or not to mark it dirty for the next ProcessSources() call.
  * \return #kEtcPalErrOk: Address added successfully.
  * \return #kEtcPalErrInvalid: Invalid parameter provided.
  * \return #kEtcPalErrNotInit: Module not initialized.
  * \return #kEtcPalErrNotFound: Handle does not correspond to a valid source or the universe is not on that source.
  * \return #kEtcPalErrSys: An internal library or system call error occurred.
  */
-inline etcpal::Error Source::AddUnicastDestination(uint16_t universe, const etcpal::IpAddr& dest, bool dirty_now)
+inline etcpal::Error Source::AddUnicastDestination(uint16_t universe, const etcpal::IpAddr& dest)
 {
-  return sacn_source_add_unicast_destination(handle_, universe, &dest.get(), dirty_now);
+  return sacn_source_add_unicast_destination(handle_, universe, &dest.get());
 }
 
 /*!

--- a/include/sacn/cpp/source.h
+++ b/include/sacn/cpp/source.h
@@ -23,6 +23,7 @@
 /// @file sacn/cpp/source.h
 /// @brief C++ wrapper for the sACN Source API
 
+#include <cstring>
 #include "sacn/source.h"
 #include "etcpal/cpp/uuid.h"
 #include "etcpal/cpp/inet.h"
@@ -49,29 +50,29 @@ public:
   /// @brief A set of configuration settings that a source needs to initialize.
   struct Settings
   {
-  /********* Required values **********/
+    /********* Required values **********/
 
-  /*! The source's CID. */
-  Uuid cid;
-  /*! The source's name, a UTF-8 encoded string. Up to #SACN_SOURCE_NAME_MAX_LEN characters will be used. */
-  std::string name;
+    /*! The source's CID. */
+    etcpal::Uuid cid;
+    /*! The source's name, a UTF-8 encoded string. Up to #SACN_SOURCE_NAME_MAX_LEN characters will be used. */
+    std::string name;
 
-  /********* Optional values **********/
+    /********* Optional values **********/
 
-  /*! The maximum number of sources this universe will send to when using dynamic memory. */
-  size_t universe_count_max{SACN_SOURCE_INFINITE_UNIVERSES};
+    /*! The maximum number of universes this source will send to when using dynamic memory. */
+    size_t universe_count_max{SACN_SOURCE_INFINITE_UNIVERSES};
 
-  /*! If non-empty, the list of network interfaces to transmit on.  Otherwise, all available interfaces are used. */
-  std::vector<SacnMcastNetintId> netints;
+    /*! If non-empty, the list of network interfaces to transmit on.  Otherwise, all available interfaces are used. */
+    std::vector<SacnMcastNetintId> netints;
 
-  /*! If false (default), this module starts a thread that calls sacn_source_process_sources() every 23 ms.
-      If true, no thread is started and the application must call sacn_source_process_sources() at its DMX rate,
-      usually 23 ms. */
-  bool manually_process_source;
+    /*! If false (default), this module starts a thread that calls sacn_source_process_sources() every 23 ms.
+        If true, no thread is started and the application must call sacn_source_process_sources() at its DMX rate,
+        usually 23 ms. */
+    bool manually_process_source{false};
 
     /// Create an empty, invalid data structure by default.
     Settings() = default;
-    Settings(const Uuid& new_cid, const std::string& new_name);
+    Settings(const etcpal::Uuid& new_cid, const std::string& new_name);
 
     bool IsValid() const;
   };
@@ -89,33 +90,27 @@ public:
 
   etcpal::Error AddUniverse(const SacnSourceUniverseConfig& config, bool dirty_now);
   void RemoveUniverse(uint16_t universe);
+
   etcpal::Error AddUnicastDestination(uint16_t universe, const etcpal::IpAddr& dest, bool dirty_now);
   void RemoveUnicastDestination(uint16_t universe, const etcpal::IpAddr& dest);
 
-  etcpal::Expected<uint16_t> GetUniverse() const;
-  etcpal::Error ChangeUniverse(uint16_t new_universe_id);
+  etcpal::Error ChangePriority(uint16_t universe, uint8_t new_priority);
+  etcpal::Error ChangePreviewFlag(uint16_t universe, bool new_preview_flag);
+  etcpal::Error ChangeSynchronizationUniverse(uint16_t universe, uint16_t new_sync_universe);
+
+  etcpal::Error SendNow(uint16_t universe, uint8_t start_code, const uint8_t* buffer, size_t buflen);
+  etcpal::Error SendSynchronization(uint16_t universe);
+
+  void SetDirty(uint16_t universe);
+  void SetListDirty(const std::vector<uint16_t>& universes);
+  void SetDirtyAndForceSync(uint16_t universe);
+
   etcpal::Error ResetNetworking(const std::vector<SacnMcastNetintId>& netints,
                                 SacnNetworkChangeResult* good_interfaces = nullptr);
 
-
-etcpal_error_t sacn_source_change_priority(sacn_source_t handle, uint16_t universe, uint8_t new_priority);
-etcpal_error_t sacn_source_change_preview_flag(sacn_source_t handle, uint16_t universe, bool new_preview_flag);
-etcpal_error_t sacn_source_change_synchronization_universe(sacn_source_t handle, uint16_t universe,
-                                                           uint16_t new_sync_universe);
-
-etcpal_error_t sacn_source_send_now(sacn_source_t handle, uint16_t universe, uint8_t start_code, const uint8_t* buffer,
-                                    size_t buflen);
-etcpal_error_t sacn_source_send_synchronization(sacn_source_t handle, uint16_t universe);
-
-void sacn_source_set_dirty(sacn_source_t handle, uint8_t universe);
-void sacn_source_set_list_dirty(sacn_source_t handle, uint8_t* universes, size_t num_universes);
-void sacn_source_set_dirty_and_force_sync(sacn_source_t handle, uint8_t universe);
-
-size_t sacn_source_process_sources(void);
-
-etcpal_error_t sacn_source_reset_networking(sacn_source_t handle, const SacnMcastNetintId* netints, size_t num_netints, SacnNetworkChangeResult* good_interfaces);
-
   constexpr Handle handle() const;
+
+  static size_t ProcessSources();
 
 private:
   SacnSourceConfig TranslateConfig(const Settings& settings);
@@ -123,126 +118,349 @@ private:
   Handle handle_{kInvalidHandle};
 };
 
-/// @brief Create a Receiver Settings instance by passing the required members explicitly.
+/// @brief Create a Source Settings instance by passing the required members explicitly.
 ///
 /// Optional members can be modified directly in the struct.
-inline Receiver::Settings::Settings(uint16_t new_universe_id) : universe_id(new_universe_id)
+inline Source::Settings::Settings(const etcpal::Uuid& new_cid, const std::string& new_name)
+    : cid(new_cid), name(new_name)
 {
 }
 
-/// Determine whether a Reciever Settings instance contains valid data for sACN operation.
-inline bool Receiver::Settings::IsValid() const
+/// Determine whether a Source Settings instance contains valid data for sACN operation.
+inline bool Source::Settings::IsValid() const
 {
-  return (universe_id > 0);
+  return !cid.IsNull();
 }
 
 /*!
- * \brief Start listening for sACN data on a universe.
+ * \brief Create a new sACN source to send sACN data.
  *
- * An sACN receiver can listen on one universe at a time, and each universe can only be listened to
- * by one receiver at at time.
+ * This creates the instance of the source, but no data is sent until AddUniverse() is called.
  *
- * Note that a receiver is considered as successfully created if it is able to successfully use any of the
+ * Note that a source is considered as successfully created if it is able to successfully use any of the
  * network interfaces listed in the passed in configuration.  This will only return #kEtcPalErrNoNetints
  * if none of the interfaces work.
  *
- * \param[in] settings Configuration parameters for the sACN receiver and this class instance.
- * \param[in] notify_handler The notification interface to call back to the application.
+ * \param[in] settings Configuration parameters for the sACN source to be created.
  * \param[in, out] good_interfaces Optional. If non-nil, good_interfaces is filled in with the list of network
  * interfaces that were succesfully used.
- * \return #kEtcPalErrOk: Receiver created successfully.
+ * \return #kEtcPalErrOk: Source successfully created.
  * \return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.
  * \return #kEtcPalErrInvalid: Invalid parameter provided.
  * \return #kEtcPalErrNotInit: Module not initialized.
- * \return #kEtcPalErrExists: A receiver already exists which is listening on the specified universe.
- * \return #kEtcPalErrNoMem: No room to allocate memory for this receiver.
+ * \return #kEtcPalErrNoMem: No room to allocate an additional source.
  * \return #kEtcPalErrNotFound: A network interface ID given was not found on the system.
  * \return #kEtcPalErrSys: An internal library or system call error occurred.
  */
-inline etcpal::Error Receiver::Startup(const Settings& settings, NotifyHandler& notify_handler,
-                                       SacnNetworkChangeResult* good_interfaces)
+inline etcpal::Error Source::Startup(const Settings& settings, SacnNetworkChangeResult* good_interfaces)
 {
-  SacnReceiverConfig config = TranslateConfig(settings, notify_handler);
-  return sacn_receiver_create(&config, &handle_, good_interfaces);
+  SacnSourceConfig config = TranslateConfig(settings);
+  return sacn_source_create(&config, &handle_, good_interfaces);
 }
 
 /*!
- * \brief Stop listening for sACN data on a universe.
+ * \brief Destroy an sACN source instance.
  *
- * Tears down the receiver and any sources currently being tracked on the receiver's universe.
- * Stops listening for sACN on that universe.
+ * Stops sending all universes for this source. The destruction is queued, and actually occurs
+ * on a call to ProcessSources() after an additional three packets have been sent with the
+ * "Stream_Terminated" option set. The source will also stop transmitting sACN universe discovery packets.
+ *
+ * Even though the destruction is queued, after this call the library will no longer use the priority_buffer
+ * or values_buffer you passed in on your call to AddUniverse().
  */
-inline void Receiver::Shutdown()
+inline void Source::Shutdown()
 {
-  sacn_receiver_destroy(handle_);
+  sacn_source_destroy(handle_);
   handle_ = kInvalidHandle;
 }
 
 /*!
- * \brief Get the universe this class is listening to.
+ * \brief Change the name of an sACN source.
  *
- * \return If valid, the value is the universe id.  Otherwise, this is the underlying error the C library call returned.
- */
-etcpal::Expected<uint16_t> Receiver::GetUniverse() const
-{
-  uint16_t result = 0;
-  etcpal_error_t err = sacn_receiver_get_universe(handle_, &result);
-  if (err == kEtcPalErrOk)
-    return result;
-  else
-    return err;
-}
-
-/*!
- * \brief Change the universe this class is listening to.
+ * The name is a UTF-8 string representing "a user-assigned name provided by the source of the
+ * packet for use in displaying the identity of a source to a user." Only up to
+ * #SACN_SOURCE_NAME_MAX_LEN characters will be used.
  *
- * An sACN receiver can only listen on one universe at a time. After this call completes successfully, the receiver is
- * in a sampling period for the new universe and will provide HandleSourcesFound() calls when appropriate.
- * If this call fails, the caller must call Shutdown() on this class, because it may be in an invalid state.
- *
- * \param[in] new_universe_id New universe number that this receiver should listen to.
- * \return #kEtcPalErrOk: Universe changed successfully.
+ * \param[in] new_name New name to use for this universe.
+ * \return #kEtcPalErrOk: Name set successfully.
  * \return #kEtcPalErrInvalid: Invalid parameter provided.
  * \return #kEtcPalErrNotInit: Module not initialized.
- * \return #kEtcPalErrExists: A receiver already exists which is listening on the specified new universe.
- * \return #kEtcPalErrNotFound: Handle does not correspond to a valid receiver.
+ * \return #kEtcPalErrNotFound: Handle does not correspond to a valid source.
  * \return #kEtcPalErrSys: An internal library or system call error occurred.
  */
-inline etcpal::Error Receiver::ChangeUniverse(uint16_t new_universe_id)
+inline etcpal::Error Source::ChangeName(const std::string& new_name)
 {
-  return sacn_receiver_change_universe(handle_, new_universe_id);
+  return sacn_source_change_name(handle_, new_name.c_str());
 }
 
 /*!
- * \brief Resets the underlying network sockets and packet receipt state for this class..
+ * \brief Add a universe to an sACN source.
+ *
+ * Adds a universe to a source. If dirty_now is true, the source will start sending values on the
+ * next call to ProcessSources(). If dirty_now is false, the applicaton must call SetDirty()
+ * to mark it ready for processing.
+ *
+ * If the source is not marked as unicast_only, the source will add the universe to its sACN Universe
+ * Discovery packets.
+
+ * \param[in] config Configuration parameters for the universe to be added.
+ * \param[in] dirty_now Whether or not to immediately mark the universe as dirty.
+ * \return #kEtcPalErrOk: Universe successfully added.
+ * \return #kEtcPalErrInvalid: Invalid parameter provided.
+ * \return #kEtcPalErrNotInit: Module not initialized.
+ * \return #kEtcPalErrExists: Universe given was already added to this source.
+ * \return #kEtcPalErrNotFound: Handle does not correspond to a valid source.
+ * \return #kEtcPalErrNoMem: No room to allocate additional universe.
+ * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ */
+inline etcpal::Error Source::AddUniverse(const SacnSourceUniverseConfig& config, bool dirty_now)
+{
+  return sacn_source_add_universe(handle_, &config, dirty_now);
+}
+
+/*!
+ * \brief Remove a universe from a source.
+ *
+ * This queues the source for removal. The destruction actually occurs
+ * on a call to ProcessSources() after an additional three packets have been sent with the
+ * "Stream_Terminated" option set.
+ *
+ * The source will also stop transmitting sACN universe discovery packets for that universe.
+ *
+ * Even though the destruction is queued, after this call the library will no longer use the priority_buffer
+ * or values_buffer you passed in on your call to AddUniverse().
+ *
+ * \param[in] universe Universe to remove.
+ */
+inline void Source::RemoveUniverse(uint16_t universe)
+{
+  sacn_source_remove_universe(handle_, universe);
+}
+
+/*!
+ * \brief Add a unicast destination for a source's universe.
+ *
+ * \param[in] universe Universe to change.
+ * \param[in] dest The destination IP.
+ * \param[in] dirty_now Whether or not to mark it dirty for the next ProcessSources() call.
+ * \return #kEtcPalErrOk: Address added successfully.
+ * \return #kEtcPalErrInvalid: Invalid parameter provided.
+ * \return #kEtcPalErrNotInit: Module not initialized.
+ * \return #kEtcPalErrNotFound: Handle does not correspond to a valid source or the universe is not on that source.
+ * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ */
+inline etcpal::Error Source::AddUnicastDestination(uint16_t universe, const etcpal::IpAddr& dest, bool dirty_now)
+{
+  return sacn_source_add_unicast_destination(handle_, universe, &dest.get(), dirty_now);
+}
+
+/*!
+ * \brief Remove a unicast destination on a source's universe.
+ *
+ * This queues the address for removal. The removal actually occurs
+ * on a call to ProcessSources() after an additional three packets have been sent with the
+ * "Stream_Terminated" option set.
+ *
+ * \param[in] universe Universe to change.
+ * \param[in] dest The destination IP.  Must match the address passed to AddUnicastDestination().
+ */
+inline void Source::RemoveUnicastDestination(uint16_t universe, const etcpal::IpAddr& dest)
+{
+  sacn_source_remove_unicast_destination(handle_, universe, &dest.get());
+}
+
+/*!
+ * \brief Change the priority of a universe on a sACN source.
+ *
+ * \param[in] universe Universe to change.
+ * \param[in] new_priority New priority of the data sent from this source. Valid range is 0 to 200,
+ *                         inclusive.
+ * \return #kEtcPalErrOk: Priority set successfully.
+ * \return #kEtcPalErrInvalid: Invalid parameter provided.
+ * \return #kEtcPalErrNotInit: Module not initialized.
+ * \return #kEtcPalErrNotFound: Handle does not correspond to a valid source or the universe is not on that source.
+ * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ */
+inline etcpal::Error Source::ChangePriority(uint16_t universe, uint8_t new_priority)
+{
+  return sacn_source_change_priority(handle_, universe, new_priority);
+}
+
+/*!
+ * \brief Change the sending_preview option on a universe of a sACN source.
+ *
+ * Sets the state of a flag in the outgoing sACN packets that indicates that the data is (from
+ * E1.31) "intended for use in visualization or media server preview applications and shall not be
+ * used to generate live output."
+ *
+ * \param[in] new_preview_flag The new sending_preview option.
+ * \return #kEtcPalErrOk: sending_preview option set successfully.
+ * \return #kEtcPalErrInvalid: Invalid parameter provided.
+ * \return #kEtcPalErrNotInit: Module not initialized.
+ * \return #kEtcPalErrNotFound: Handle does not correspond to a valid source or the universe is not on that source.
+ * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ */
+inline etcpal::Error Source::ChangePreviewFlag(uint16_t universe, bool new_preview_flag)
+{
+  return sacn_source_change_preview_flag(handle_, universe, new_preview_flag);
+}
+
+/*!
+ * \brief Changes the synchronize uinverse for a universe of a sACN source.
+ *
+ * This will change the synchronization universe used by a sACN universe on the source.
+ * If this value is 0, synchronization is turned off for that universe.
+ *
+ * TODO: At this time, synchronization is not supported by this library.
+ *
+ * \param[in] universe The universe to change.
+ * \param[in] new_sync_universe The new synchronization universe to set.
+ * \return #kEtcPalErrOk: sync_universe set successfully.
+ * \return #kEtcPalErrInvalid: Invalid parameter provided.
+ * \return #kEtcPalErrNotInit: Module not initialized.
+ * \return #kEtcPalErrNotFound: Handle does not correspond to a valid source or the universe is not on that source.
+ * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ */
+inline etcpal::Error Source::ChangeSynchronizationUniverse(uint16_t universe, uint16_t new_sync_universe)
+{
+  return sacn_source_change_synchronization_universe(handle_, universe, new_sync_universe);
+}
+
+/*!
+ * \brief Immediately sends the provided sACN start code & data.
+ *
+ * Immediately sends a sACN packet with the provided start code and data.
+ * This function is intended for sACN packets that have a startcode other than 0 or 0xdd, since those
+ * start codes are taken care of by ProcessSources().
+ *
+ * \param[in] universe Universe to send on.
+ * \param[in] start_code The start code to send.
+ * \param[in] buffer The buffer to send.  Must not be NULL.
+ * \param[in] buflen The size of buffer.
+ * \return #kEtcPalErrOk: Message successfully sent.
+ * \return #kEtcPalErrInvalid: Invalid parameter provided.
+ * \return #kEtcPalErrNotInit: Module not initialized.
+ * \return #kEtcPalErrNotFound: Handle does not correspond to a valid source, or the universe was not found on this
+ *                              source.
+ * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ */
+inline etcpal::Error Source::SendNow(uint16_t universe, uint8_t start_code, const uint8_t* buffer, size_t buflen)
+{
+  return sacn_source_send_now(handle_, universe, start_code, buffer, buflen);
+}
+
+/*!
+ * \brief Immediately sends a synchronization packet for the universe on a source.
+ *
+ * This will cause an immediate transmission of a synchronization packet for the source/universe.
+ * If the universe does not have a synchronization universe configured, this call is ignored.
+ *
+ * TODO: At this time, synchronization is not supported by this library.
+ *
+ * \param[in] universe Universe to send on.
+ * \return #kEtcPalErrOk: Message successfully sent.
+ * \return #kEtcPalErrInvalid: Invalid parameter provided.
+ * \return #kEtcPalErrNotInit: Module not initialized.
+ * \return #kEtcPalErrNotFound: Handle does not correspond to a valid source, or the universe was not found on this
+ *                              source.
+ * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ */
+inline etcpal::Error Source::SendSynchronization(uint16_t universe)
+{
+  return sacn_source_send_synchronization(handle_, universe);
+}
+
+/*!
+ * \brief Indicate that the data in the buffer for this source and universe has changed and
+ *        should be sent on the next call to ProcessSources().
+ *
+ * \param[in] universe Universe to mark as dirty.
+ */
+inline void Source::SetDirty(uint16_t universe)
+{
+  sacn_source_set_dirty(handle_, universe);
+}
+
+/*!
+ * \brief Indicate that the data in the buffers for a list of universes on a source  has
+ *        changed and should be sent on the next call to ProcessSources().
+ *
+ * \param[in] universes Vector of universes to mark as dirty.
+ */
+inline void Source::SetListDirty(const std::vector<uint16_t>& universes)
+{
+  sacn_source_set_list_dirty(handle_, universes.data(), universes.size());
+}
+
+/*!
+ * \brief Like sacn_source_set_dirty, but also sets the force_sync flag on the packet.
+ *
+ * This function indicates that the data in the buffer for this source and universe has changed,
+ * and should be sent on the next call to ProcessSources().  Additionally, the packet
+ * to be sent will have its force_synchronization option flag set.
+ *
+ * If no synchronization universe is configured, this function acts like a direct call to SetDirty().
+ *
+ * TODO: At this time, synchronization is not supported by this library.
+ *
+ * \param[in] universe Universe to mark as dirty.
+ */
+inline void Source::SetDirtyAndForceSync(uint16_t universe)
+{
+  sacn_source_set_dirty_and_force_sync(handle_, universe);
+}
+
+/*!
+ * \brief Process created sources and do the actual sending of sACN data on all universes.
+ *
+ * Note: Unless you created the source with manually_process_source set to true, this will be automatically
+ * called by an internal thread of the module. Otherwise, this must be called at the maximum rate
+ * at which the application will send sACN.
+ *
+ * Sends data for universes which have been marked dirty, and sends keep-alive data for universes which are
+ * haven't changed. Also destroys sources & universes that have been marked for termination after sending the required
+ * three terminated packets.
+ *
+ * \return Current number of sources tracked by the library. This can be useful on shutdown to
+ *         track when destroyed sources have finished sending the terminated packets and actually
+ *         been destroyed.
+ */
+inline size_t Source::ProcessSources()
+{
+  return sacn_source_process_sources();
+}
+
+/*!
+ * \brief Resets the underlying network sockets for the sACN source..
  *
  * This is typically used when the application detects that the list of networking interfaces has changed.
  *
- * After this call completes successfully, the receiver is in a sampling period for the new universe and will provide
- * HandleSourcesFound() calls when appropriate.
- * If this call fails, the caller must call Shutdown() on this class, because it may be in an invalid state.
+ * After this call completes successfully, the all universes on a source are considered new & dirty by the
+ * per-address priority logic in ProcessSources.
+ *
+ * If this call fails, the caller must call Shutdown(), because the source may be in an invalid state.
  *
  * Note that the networking reset is considered successful if it is able to successfully use any of the
  * network interfaces passed in.  This will only return #kEtcPalErrNoNetints if none of the interfaces work.
  *
- * \param[in] netints Vector of network interfaces on which to listen to the specified universe. If empty,
+ * \param[in] netints Optional array of network interfaces on which to send to the specified universe. If empty,
  *  all available network interfaces will be used.
- * \param[in, out] good_interfaces Optional. If non-nil, good_interfaces is filled in with the list of network
+ * \param[in, out] good_interfaces Optional. If non-NULL, good_interfaces is filled in with the list of network
  * interfaces that were succesfully used.
- * \return #kEtcPalErrOk: Universe changed successfully.
+ * \return #kEtcPalErrOk: Source changed successfully.
  * \return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.
  * \return #kEtcPalErrInvalid: Invalid parameter provided.
  * \return #kEtcPalErrNotInit: Module not initialized.
  * \return #kEtcPalErrNotFound: Handle does not correspond to a valid receiver.
  * \return #kEtcPalErrSys: An internal library or system call error occurred.
  */
-inline etcpal::Error Receiver::ResetNetworking(const std::vector<SacnMcastNetintId>& netints,
-                                               SacnNetworkChangeResult* good_interfaces)
+inline etcpal::Error Source::ResetNetworking(const std::vector<SacnMcastNetintId>& netints,
+                                             SacnNetworkChangeResult* good_interfaces)
 {
   if (netints.empty())
-    return sacn_receiver_reset_networking(handle_, nullptr, 0, good_interfaces);
+    return sacn_source_reset_networking(handle_, nullptr, 0, good_interfaces);
   else
-    return sacn_receiver_reset_networking(handle_, netints.data(), netints.size(), good_interfaces);
+    return sacn_source_reset_networking(handle_, netints.data(), netints.size(), good_interfaces);
 }
 
 /*!
@@ -255,27 +473,28 @@ inline constexpr Source::Handle Source::handle() const
   return handle_;
 }
 
-inline SacnSourceConfig Source::TranslateConfig(const Settings& settings, NotifyHandler& notify_handler)
+inline SacnSourceConfig Source::TranslateConfig(const Settings& settings)
 {
   // clang-format off
-  SacnReceiverConfig config = {
-    settings.universe_id,
-    {
-      internal::ReceiverCbSourcesFound,
-      internal::ReceiverCbUniverseData,
-      internal::ReceiverCbSourcesLost,
-      internal::ReceiverCbPapLost,
-      internal::ReceiverCbSourceLimitExceeded,
-      &notify_handler
-    },
-    settings.source_count_max,
-    settings.flags,
-    nullptr, 
-    settings.netints.size()
+  SacnSourceConfig config = {
+    settings.cid.get(),
+    "",
+    settings.universe_count_max,
+    nullptr,
+    settings.netints.size(),
+    settings.manually_process_source,
   };
   // clang-format on
 
-  // Now initialize the netints
+  ETCPAL_MSVC_BEGIN_NO_DEP_WARNINGS();
+
+  // Update the string
+  strncpy(config.name, settings.name.c_str(), SACN_SOURCE_NAME_MAX_LEN);
+  config.name[SACN_SOURCE_NAME_MAX_LEN - 1] = 0;
+
+  ETCPAL_MSVC_END_NO_DEP_WARNINGS();
+
+  // And the interfaces
   if (config.num_netints > 0)
   {
     config.netints = settings.netints.data();

--- a/include/sacn/cpp/source.h
+++ b/include/sacn/cpp/source.h
@@ -65,8 +65,8 @@ public:
     /*! If non-empty, the list of network interfaces to transmit on.  Otherwise, all available interfaces are used. */
     std::vector<SacnMcastNetintId> netints;
 
-    /*! If false (default), this module starts a thread that calls sacn_source_process_sources() every 23 ms.
-        If true, no thread is started and the application must call sacn_source_process_sources() at its DMX rate,
+    /*! If false (default), this module starts a thread that calls ProcessSources() every 23 ms.
+        If true, no thread is started and the application must call ProcessSources() at its DMX rate,
         usually 23 ms. */
     bool manually_process_source{false};
 

--- a/include/sacn/dmx_merger.h
+++ b/include/sacn/dmx_merger.h
@@ -17,11 +17,11 @@
  * https://github.com/ETCLabs/sACN
  *****************************************************************************/
 
-/*!
- * \file sacn/dmx_merger.h
- * \brief sACN DMX Merger API definitions
+/**
+ * @file sacn/dmx_merger.h
+ * @brief sACN DMX Merger API definitions
  *
- * Functions and definitions for the \ref sacn_dmx_merger "sACN DMX Merger API" are contained in this
+ * Functions and definitions for the @ref sacn_dmx_merger "sACN DMX Merger API" are contained in this
  * header.
  */
 
@@ -35,10 +35,10 @@
 #include "sacn/common.h"
 #include "sacn/receiver.h"
 
-/*!
- * \defgroup sacn_dmx_merger sACN DMX Merger
- * \ingroup sACN
- * \brief The sACN DMX Merger API
+/**
+ * @defgroup sacn_dmx_merger sACN DMX Merger
+ * @ingroup sACN
+ * @brief The sACN DMX Merger API
  *
  * This API provides a software merger for buffers containing DMX512-A start code 0 packets.
  * It also uses buffers containing DMX512-A start code 0xdd packets to support per-address priority.
@@ -57,7 +57,7 @@
  * This API is thread-safe.
  *
  * Usage:
- * \code
+ * @code
  * // Initialize sACN.
  * EtcPalLogParams log_params = ETCPAL_LOG_PARAMS_INIT;
  * // Init log params here...
@@ -130,7 +130,7 @@
  *
  * // Or, if sACN is deinitialized, all of the mergers are destroyed automatically:
  * sacn_deinit();
- * \endcode
+ * @endcode
  *
  * @{
  */
@@ -139,31 +139,31 @@
 extern "C" {
 #endif
 
-/*! Each merger has a handle associated with it.*/
+/** Each merger has a handle associated with it.*/
 typedef int sacn_dmx_merger_t;
 
-/*! An invalid sACN merger handle value. */
+/** An invalid sACN merger handle value. */
 #define SACN_DMX_MERGER_INVALID -1
 
-/*! The sources on a merger have a short id that is used in the owned values, rather than a UUID.*/
+/** The sources on a merger have a short id that is used in the owned values, rather than a UUID.*/
 typedef uint16_t sacn_source_id_t;
 
-/*! An invalid source id handle value. */
+/** An invalid source id handle value. */
 #define SACN_DMX_MERGER_SOURCE_INVALID ((sacn_source_id_t) -1)
 
-/*! A set of configuration information for a merger instance. */
+/** A set of configuration information for a merger instance. */
 typedef struct SacnDmxMergerConfig
 {
-  /*! The maximum number of sources this merger will listen to.  May be #SACN_RECEIVER_INFINITE_SOURCES.
+  /** The maximum number of sources this merger will listen to.  May be #SACN_RECEIVER_INFINITE_SOURCES.
       This parameter is ignored when configured to use static memory -- #SACN_DMX_MERGER_MAX_SOURCES_PER_MERGER is used
       instead.*/
   size_t source_count_max;
 
-  /*! Buffer of #DMX_ADDRESS_COUNT levels that this library keeps up to date as it merges.
+  /** Buffer of #DMX_ADDRESS_COUNT levels that this library keeps up to date as it merges.
       Memory is owned by the application.*/
   uint8_t* slots;
 
-  /*! Buffer of #DMX_ADDRESS_COUNT source IDs that indicate the current winner of the merge for
+  /** Buffer of #DMX_ADDRESS_COUNT source IDs that indicate the current winner of the merge for
       that slot, or #DMX_MERGER_SOURCE_INVALID to indicate that no source is providing values for that slot.
       You can use SACN_DMX_MERGER_SOURCE_IS_VALID() if you don't want to look at the slot_owners directly.
       Memory is owned by the application.*/
@@ -171,15 +171,15 @@ typedef struct SacnDmxMergerConfig
 
 } SacnDmxMergerConfig;
 
-/*!
- * \brief An initializer for an SacnDmxMergerConfig struct.
+/**
+ * @brief An initializer for an SacnDmxMergerConfig struct.
  *
  * Usage:
- * \code
+ * @code
  * // Create the struct
  * SacnDmxMergerConfig merger_config = SACN_DMX_MERGER_CONFIG_INIT;
  * // Now fill in the members of the struct
- * \endcode
+ * @endcode
  *
  */
 #define SACN_DMX_MERGER_CONFIG_INIT \
@@ -187,8 +187,8 @@ typedef struct SacnDmxMergerConfig
     0, NULL, NULL                   \
   }
 
-/*!
- * \brief Utility to see if a slot_owner is valid.
+/**
+ * @brief Utility to see if a slot_owner is valid.
  *
  * Given a buffer of slot_owners, evaluate to true if the slot is != DMX_MERGER_SOURCE_INVALID.
  *
@@ -196,26 +196,26 @@ typedef struct SacnDmxMergerConfig
 #define SACN_DMX_MERGER_SOURCE_IS_VALID(slot_owners_array, slot_index) \
   (slot_owners_array[slot_index] != SACN_DMX_MERGER_SOURCE_INVALID)
 
-/*! The current input data for a single source of the merge.  This is exposed only for informational purposes, as the
+/** The current input data for a single source of the merge.  This is exposed only for informational purposes, as the
     application calls a variant of sacn_dmx_merger_update_source to do the actual update. */
 typedef struct SacnDmxMergerSource
 {
-  /*! The UUID (e.g. sACN CID) of the DMX source. */
+  /** The UUID (e.g. sACN CID) of the DMX source. */
   EtcPalUuid cid;
 
-  /*! The DMX data values (0 - 255). */
+  /** The DMX data values (0 - 255). */
   uint8_t values[DMX_ADDRESS_COUNT];
 
-  /*! Some sources don't send all 512 values, so here's how much of values to use.*/
+  /** Some sources don't send all 512 values, so here's how much of values to use.*/
   size_t valid_value_count;
 
-  /*! The sACN per-universe priority (0 - 200). */
+  /** The sACN per-universe priority (0 - 200). */
   uint8_t universe_priority;
 
-  /*! Whether or not the address_priority buffer is valid. */
+  /** Whether or not the address_priority buffer is valid. */
   bool address_priority_valid;
 
-  /*! The sACN per-address (startcode 0xdd) priority (1-255, 0 means not sourced).
+  /** The sACN per-address (startcode 0xdd) priority (1-255, 0 means not sourced).
       If the source does not have per-address priority, then address_priority_valid will be false, and this array should
       be ignored. */
   uint8_t address_priority[DMX_ADDRESS_COUNT];
@@ -241,7 +241,7 @@ etcpal_error_t sacn_dmx_merger_stop_source_per_address_priority(sacn_dmx_merger_
 }
 #endif
 
-/*!
+/**
  * @}
  */
 

--- a/include/sacn/merge_receiver.h
+++ b/include/sacn/merge_receiver.h
@@ -17,11 +17,11 @@
  * https://github.com/ETCLabs/sACN
  *****************************************************************************/
 
-/*!
- * \file sacn/merge_receiver.h
- * \brief sACN Merge Receiver API definitions
+/**
+ * @file sacn/merge_receiver.h
+ * @brief sACN Merge Receiver API definitions
  *
- * Functions and definitions for the \ref sacn_merge_receiver "sACN Merge Receiver API" are contained in this header.
+ * Functions and definitions for the @ref sacn_merge_receiver "sACN Merge Receiver API" are contained in this header.
  */
 
 #ifndef SACN_MERGE_RECEIVER_H_
@@ -32,10 +32,10 @@
 #include "sacn/receiver.h"
 #include "sacn/dmx_merger.h"
 
-/*!
- * \defgroup sacn_merge_receiver sACN Merge Receiver
- * \ingroup sACN
- * \brief The sACN Merge Receiver API
+/**
+ * @defgroup sacn_merge_receiver sACN Merge Receiver
+ * @ingroup sACN
+ * @brief The sACN Merge Receiver API
  *
  * This API is used to minimally wrap the sACN Receiver and DMX Merger logic together so an application can receive and
  * merge sACN sources in software.
@@ -47,13 +47,13 @@
 extern "C" {
 #endif
 
-/*! A handle to an sACN Merge Receiver. */
+/** A handle to an sACN Merge Receiver. */
 typedef int sacn_merge_receiver_t;
-/*! An invalid sACN merge_receiver handle value. */
+/** An invalid sACN merge_receiver handle value. */
 #define SACN_MERGE_RECEIVER_INVALID -1
 
-/*!
- * \brief Notify that a new data packet has been received and merged.
+/**
+ * @brief Notify that a new data packet has been received and merged.
  *
  * This callback will be called in multiple ways:
  * 1. When a new non-preview data packet or per-address priority packet is received from the sACN Receiver module,
@@ -67,22 +67,22 @@ typedef int sacn_merge_receiver_t;
  * This callback should be processed quickly, since it will interfere with the receipt and processing of other sACN
  * packets on the universe.
  *
- * \param[in] handle The handle to the merge receiver instance.
- * \param[in] universe The universe this merge receiver is monitoring.
- * \param[in] slots Buffer of #DMX_ADDRESS_COUNT bytes containing the merged levels for the universe. This buffer is
+ * @param[in] handle The handle to the merge receiver instance.
+ * @param[in] universe The universe this merge receiver is monitoring.
+ * @param[in] slots Buffer of #DMX_ADDRESS_COUNT bytes containing the merged levels for the universe. This buffer is
  * owned by the library.
- * \param[in] slot_owners Buffer of #DMX_ADDRESS_COUNT source_ids.  If a value in the buffer is
+ * @param[in] slot_owners Buffer of #DMX_ADDRESS_COUNT source_ids.  If a value in the buffer is
  *           #DMX_MERGER_SOURCE_INVALID, the corresponding slot is not currently controlled. You can also use
  *            SACN_DMX_MERGER_SOURCE_IS_VALID(slot_owners, index) to check the slot validity. This buffer is owned by
  * the library.
- * \param[in] context Context pointer that was given at the creation of the merge receiver instance.
+ * @param[in] context Context pointer that was given at the creation of the merge receiver instance.
  */
 typedef void (*SacnMergeReceiverMergedDataCallback)(sacn_merge_receiver_t handle, uint16_t universe,
                                                     const uint8_t* slots, const sacn_source_id_t* slot_owners,
                                                     void* context);
 
-/*!
- * \brief Notify that a non-data packet has been received.
+/**
+ * @brief Notify that a non-data packet has been received.
  *
  * When an established source sends a sACN data packet that doesn't contain DMX values or priorities, the raw packet is
  * immediately and synchronously passed to this callback.
@@ -94,59 +94,59 @@ typedef void (*SacnMergeReceiverMergedDataCallback)(sacn_merge_receiver_t handle
  * if the source forces the packet, or if the source sends a data packet without a sync universe.
  * TODO: this version of the sACN library does not support sACN Sync. This paragraph will be valid in the future.
  *
- * \param[in] handle The handle to the merge receiver instance.
- * \param[in] universe The universe this merge receiver is monitoring.
- * \param[in] source_addr The network address from which the sACN packet originated.
- * \param[in] header The header data of the sACN packet.
- * \param[in] pdata Pointer to the data buffer. Size of the buffer is indicated by header->slot_count. This buffer is
+ * @param[in] handle The handle to the merge receiver instance.
+ * @param[in] universe The universe this merge receiver is monitoring.
+ * @param[in] source_addr The network address from which the sACN packet originated.
+ * @param[in] header The header data of the sACN packet.
+ * @param[in] pdata Pointer to the data buffer. Size of the buffer is indicated by header->slot_count. This buffer is
  * owned by the library.
- * \param[in] context Context pointer that was given at the creation of the merge receiver instance.
+ * @param[in] context Context pointer that was given at the creation of the merge receiver instance.
  */
 typedef void (*SacnMergeReceiverNonDmxCallback)(sacn_merge_receiver_t handle, uint16_t universe,
                                                 const EtcPalSockAddr* source_addr, const SacnHeaderData* header,
                                                 const uint8_t* pdata, void* context);
 
-/*!
- * \brief Notify that more than the configured maximum number of sources are currently sending on
+/**
+ * @brief Notify that more than the configured maximum number of sources are currently sending on
  *        the universe being listened to.
  *
  * This is a notification that is directly forwarded from the sACN Receiver module.
  *
- * \param[in] handle Handle to the merge receiver instance for which the source limit has been exceeded.
- * \param[in] universe The universe this merge receiver is monitoring.
- * \param[in] context Context pointer that was given at the creation of the merge receiver instance.
+ * @param[in] handle Handle to the merge receiver instance for which the source limit has been exceeded.
+ * @param[in] universe The universe this merge receiver is monitoring.
+ * @param[in] context Context pointer that was given at the creation of the merge receiver instance.
  */
 typedef void (*SacnMergeReceiverSourceLimitExceededCallback)(sacn_merge_receiver_t handle, uint16_t universe,
                                                              void* context);
 
-/*! A set of callback functions that the library uses to notify the application about sACN events. */
+/** A set of callback functions that the library uses to notify the application about sACN events. */
 typedef struct SacnMergeReceiverCallbacks
 {
-  SacnMergeReceiverMergedDataCallback universe_data;                  /*!< Required */
-  SacnMergeReceiverNonDmxCallback universe_non_dmx;                   /*!< Required */
-  SacnMergeReceiverSourceLimitExceededCallback source_limit_exceeded; /*!< Optional */
-  void* callback_context; /*!< (optional) Pointer to opaque data passed back with each callback. */
+  SacnMergeReceiverMergedDataCallback universe_data;                  /**< Required */
+  SacnMergeReceiverNonDmxCallback universe_non_dmx;                   /**< Required */
+  SacnMergeReceiverSourceLimitExceededCallback source_limit_exceeded; /**< Optional */
+  void* callback_context; /**< (optional) Pointer to opaque data passed back with each callback. */
 } SacnMergeReceiverCallbacks;
 
-/*! A set of configuration information for an sACN merge receiver. */
+/** A set of configuration information for an sACN merge receiver. */
 typedef struct SacnMergeReceiverConfig
 {
   /********* Required values **********/
 
-  /*! Universe number on which to listen for sACN. */
+  /** Universe number on which to listen for sACN. */
   uint16_t universe_id;
-  /*! The callbacks this merge receiver will use to notify the application of events. */
+  /** The callbacks this merge receiver will use to notify the application of events. */
   SacnMergeReceiverCallbacks callbacks;
 
   /********* Optional values **********/
 
-  /*! The maximum number of sources this universe will listen to.  May be #SACN_RECEIVER_INFINITE_SOURCES.
+  /** The maximum number of sources this universe will listen to.  May be #SACN_RECEIVER_INFINITE_SOURCES.
       This parameter is ignored when configured to use static memory -- #SACN_RECEIVER_MAX_SOURCES_PER_UNIVERSE is used
      instead.*/
   size_t source_count_max;
 } SacnMergeReceiverConfig;
 
-/*! A default-value initializer for an SacnMergeReceiverConfig struct. */
+/** A default-value initializer for an SacnMergeReceiverConfig struct. */
 #define SACN_MERGE_RECEIVER_CONFIG_DEFAULT_INIT \
   {                                             \
     0, {NULL, NULL, NULL}, 0                    \
@@ -169,7 +169,7 @@ etcpal_error_t sacn_merge_receiver_get_source_cid(sacn_merge_receiver_t handle, 
 }
 #endif
 
-/*!
+/**
  * @}
  */
 

--- a/include/sacn/merge_receiver.h
+++ b/include/sacn/merge_receiver.h
@@ -155,12 +155,12 @@ typedef struct SacnMergeReceiverConfig
 void sacn_merge_receiver_config_init(SacnMergeReceiverConfig* config);
 
 etcpal_error_t sacn_merge_receiver_create(const SacnMergeReceiverConfig* config, sacn_merge_receiver_t* handle,
-                                          SacnMcastInterfaceToUse* ifaces, size_t ifaces_count);
+                                          SacnMcastInterface* netints, size_t num_netints);
 etcpal_error_t sacn_merge_receiver_destroy(sacn_merge_receiver_t handle);
 etcpal_error_t sacn_merge_receiver_get_universe(sacn_merge_receiver_t handle, uint16_t* universe_id);
 etcpal_error_t sacn_merge_receiver_change_universe(sacn_merge_receiver_t handle, uint16_t new_universe_id);
-etcpal_error_t sacn_merge_receiver_reset_networking(sacn_merge_receiver_t handle, SacnMcastInterfaceToUse* ifaces,
-                                                    size_t ifaces_count);
+etcpal_error_t sacn_merge_receiver_reset_networking(sacn_merge_receiver_t handle, SacnMcastInterface* netints,
+                                                    size_t num_netints);
 sacn_source_id_t sacn_merge_receiver_get_source_id(sacn_merge_receiver_t handle, const EtcPalUuid* source_cid);
 etcpal_error_t sacn_merge_receiver_get_source_cid(sacn_merge_receiver_t handle, sacn_source_id_t source_id,
                                                   EtcPalUuid* source_cid);

--- a/include/sacn/merge_receiver.h
+++ b/include/sacn/merge_receiver.h
@@ -144,28 +144,23 @@ typedef struct SacnMergeReceiverConfig
       This parameter is ignored when configured to use static memory -- #SACN_RECEIVER_MAX_SOURCES_PER_UNIVERSE is used
      instead.*/
   size_t source_count_max;
-  /*! (optional) array of network interfaces on which to listen to the specified universe. If NULL,
-   *  all available network interfaces will be used. */
-  const SacnMcastNetintId* netints;
-  /*! Number of elements in the netints array. */
-  size_t num_netints;
 } SacnMergeReceiverConfig;
 
 /*! A default-value initializer for an SacnMergeReceiverConfig struct. */
 #define SACN_MERGE_RECEIVER_CONFIG_DEFAULT_INIT \
   {                                             \
-    0, {NULL, NULL, NULL}, 0, NULL, NULL, 0     \
+    0, {NULL, NULL, NULL}, 0                    \
   }
 
 void sacn_merge_receiver_config_init(SacnMergeReceiverConfig* config);
 
 etcpal_error_t sacn_merge_receiver_create(const SacnMergeReceiverConfig* config, sacn_merge_receiver_t* handle,
-                                          SacnNetworkChangeResult* good_interfaces);
+                                          SacnMcastInterfaceToUse* ifaces, size_t ifaces_count);
 etcpal_error_t sacn_merge_receiver_destroy(sacn_merge_receiver_t handle);
 etcpal_error_t sacn_merge_receiver_get_universe(sacn_merge_receiver_t handle, uint16_t* universe_id);
 etcpal_error_t sacn_merge_receiver_change_universe(sacn_merge_receiver_t handle, uint16_t new_universe_id);
-etcpal_error_t sacn_merge_receiver_reset_networking(sacn_merge_receiver_t handle, const SacnMcastNetintId* netints,
-                                                    size_t num_netints, SacnNetworkChangeResult* good_interfaces);
+etcpal_error_t sacn_merge_receiver_reset_networking(sacn_merge_receiver_t handle, SacnMcastInterfaceToUse* ifaces,
+                                                    size_t ifaces_count);
 sacn_source_id_t sacn_merge_receiver_get_source_id(sacn_merge_receiver_t handle, const EtcPalUuid* source_cid);
 etcpal_error_t sacn_merge_receiver_get_source_cid(sacn_merge_receiver_t handle, sacn_source_id_t source_id,
                                                   EtcPalUuid* source_cid);

--- a/include/sacn/merge_receiver.h
+++ b/include/sacn/merge_receiver.h
@@ -39,7 +39,7 @@
  *
  * This API is used to minimally wrap the sACN Receiver and DMX Merger logic together so an application can receive and
  * merge sACN sources in software.
- * 
+ *
  * @{
  */
 
@@ -116,7 +116,8 @@ typedef void (*SacnMergeReceiverNonDmxCallback)(sacn_merge_receiver_t handle, ui
  * \param[in] universe The universe this merge receiver is monitoring.
  * \param[in] context Context pointer that was given at the creation of the merge receiver instance.
  */
-typedef void (*SacnMergeReceiverSourceLimitExceededCallback)(sacn_merge_receiver_t handle, uint16_t universe, void* context);
+typedef void (*SacnMergeReceiverSourceLimitExceededCallback)(sacn_merge_receiver_t handle, uint16_t universe,
+                                                             void* context);
 
 /*! A set of callback functions that the library uses to notify the application about sACN events. */
 typedef struct SacnMergeReceiverCallbacks
@@ -158,12 +159,13 @@ typedef struct SacnMergeReceiverConfig
 
 void sacn_merge_receiver_config_init(SacnMergeReceiverConfig* config);
 
-etcpal_error_t sacn_merge_receiver_create(const SacnMergeReceiverConfig* config, sacn_merge_receiver_t* handle);
+etcpal_error_t sacn_merge_receiver_create(const SacnMergeReceiverConfig* config, sacn_merge_receiver_t* handle,
+                                          SacnNetworkChangeResult* good_interfaces);
 etcpal_error_t sacn_merge_receiver_destroy(sacn_merge_receiver_t handle);
 etcpal_error_t sacn_merge_receiver_get_universe(sacn_merge_receiver_t handle, uint16_t* universe_id);
 etcpal_error_t sacn_merge_receiver_change_universe(sacn_merge_receiver_t handle, uint16_t new_universe_id);
 etcpal_error_t sacn_merge_receiver_reset_networking(sacn_merge_receiver_t handle, const SacnMcastNetintId* netints,
-                                                    size_t num_netints);
+                                                    size_t num_netints, SacnNetworkChangeResult* good_interfaces);
 sacn_source_id_t sacn_merge_receiver_get_source_id(sacn_merge_receiver_t handle, const EtcPalUuid* source_cid);
 etcpal_error_t sacn_merge_receiver_get_source_cid(sacn_merge_receiver_t handle, sacn_source_id_t source_id,
                                                   EtcPalUuid* source_cid);

--- a/include/sacn/receiver.h
+++ b/include/sacn/receiver.h
@@ -270,27 +270,23 @@ typedef struct SacnReceiverConfig
   size_t source_count_max;
   /*! A set of option flags. See "sACN receiver flags". */
   unsigned int flags;
-  /*! (optional) array of network interfaces on which to listen to the specified universe. If NULL,
-   *  all available network interfaces will be used. */
-  const SacnMcastNetintId* netints;
-  /*! Number of elements in the netints array. */
-  size_t num_netints;
 } SacnReceiverConfig;
 
 /*! A default-value initializer for an SacnReceiverConfig struct. */
 #define SACN_RECEIVER_CONFIG_DEFAULT_INIT                  \
   {                                                        \
-    0, {NULL, NULL, NULL, NULL, NULL, NULL}, 0, 0, NULL, 0 \
+    0, {NULL, NULL, NULL, NULL, NULL, NULL}, 0, 0,         \
   }
 
 void sacn_receiver_config_init(SacnReceiverConfig* config);
 
-etcpal_error_t sacn_receiver_create(const SacnReceiverConfig* config, sacn_receiver_t* handle, SacnNetworkChangeResult* good_interfaces);
+etcpal_error_t sacn_receiver_create(const SacnReceiverConfig* config, sacn_receiver_t* handle,
+                                    SacnMcastInterfaceToUse* ifaces, size_t ifaces_count);
 etcpal_error_t sacn_receiver_destroy(sacn_receiver_t handle);
 etcpal_error_t sacn_receiver_get_universe(sacn_receiver_t handle, uint16_t* universe_id);
 etcpal_error_t sacn_receiver_change_universe(sacn_receiver_t handle, uint16_t new_universe_id);
-etcpal_error_t sacn_receiver_reset_networking(sacn_receiver_t handle, const SacnMcastNetintId* netints,
-                                              size_t num_netints, SacnNetworkChangeResult* good_interfaces);
+etcpal_error_t sacn_receiver_reset_networking(sacn_receiver_t handle, SacnMcastInterfaceToUse* ifaces,
+                                              size_t ifaces_count);
 
 void sacn_receiver_set_standard_version(sacn_standard_version_t version);
 sacn_standard_version_t sacn_receiver_get_standard_version();

--- a/include/sacn/receiver.h
+++ b/include/sacn/receiver.h
@@ -281,12 +281,12 @@ typedef struct SacnReceiverConfig
 void sacn_receiver_config_init(SacnReceiverConfig* config);
 
 etcpal_error_t sacn_receiver_create(const SacnReceiverConfig* config, sacn_receiver_t* handle,
-                                    SacnMcastInterfaceToUse* ifaces, size_t ifaces_count);
+                                    SacnMcastInterface* netints, size_t num_netints);
 etcpal_error_t sacn_receiver_destroy(sacn_receiver_t handle);
 etcpal_error_t sacn_receiver_get_universe(sacn_receiver_t handle, uint16_t* universe_id);
 etcpal_error_t sacn_receiver_change_universe(sacn_receiver_t handle, uint16_t new_universe_id);
-etcpal_error_t sacn_receiver_reset_networking(sacn_receiver_t handle, SacnMcastInterfaceToUse* ifaces,
-                                              size_t ifaces_count);
+etcpal_error_t sacn_receiver_reset_networking(sacn_receiver_t handle, SacnMcastInterface* netints,
+                                              size_t num_netints);
 
 void sacn_receiver_set_standard_version(sacn_standard_version_t version);
 sacn_standard_version_t sacn_receiver_get_standard_version();

--- a/include/sacn/receiver.h
+++ b/include/sacn/receiver.h
@@ -17,11 +17,11 @@
  * https://github.com/ETCLabs/sACN
  *****************************************************************************/
 
-/*!
- * \file sacn/receiver.h
- * \brief sACN Receiver API definitions
+/**
+ * @file sacn/receiver.h
+ * @brief sACN Receiver API definitions
  *
- * Functions and definitions for the \ref sacn_receiver "sACN Receiver API" are contained in this
+ * Functions and definitions for the @ref sacn_receiver "sACN Receiver API" are contained in this
  * header.
  */
 
@@ -37,10 +37,10 @@
 #include "etcpal/uuid.h"
 #include "sacn/common.h"
 
-/*!
- * \defgroup sacn_receiver sACN Receiver
- * \ingroup sACN
- * \brief The sACN Receiver API
+/**
+ * @defgroup sacn_receiver sACN Receiver
+ * @ingroup sACN
+ * @brief The sACN Receiver API
  *
  * Components that receive sACN are referred to as sACN Receivers. Use this API to act as an sACN
  * Receiver.
@@ -52,30 +52,30 @@
 extern "C" {
 #endif
 
-/*! A handle to an sACN receiver. */
+/** A handle to an sACN receiver. */
 typedef int sacn_receiver_t;
-/*! An invalid sACN receiver handle value. */
+/** An invalid sACN receiver handle value. */
 #define SACN_RECEIVER_INVALID -1
 
-/*!
- * \brief Constant for "infinite" when listening or merging sACN universes.
+/**
+ * @brief Constant for "infinite" when listening or merging sACN universes.
  *
  * When using dynamic memory, this constant can be passed in when creating a receiver or a merger.
  * It represents an infinite number of sources on that universe.
  */
 #define SACN_RECEIVER_INFINITE_SOURCES 0
 
-/*! An identifier for a version of the sACN standard. */
+/** An identifier for a version of the sACN standard. */
 typedef enum
 {
-  kSacnStandardVersionNone,      /*!< Neither the draft nor the ratified sACN version. */
-  kSacnStandardVersionDraft,     /*!< The 2006 draft sACN standard version. */
-  kSacnStandardVersionPublished, /*!< The current published sACN standard version. */
-  kSacnStandardVersionAll        /*!< Both the current published and 2006 draft sACN standard version. */
+  kSacnStandardVersionNone,      /**< Neither the draft nor the ratified sACN version. */
+  kSacnStandardVersionDraft,     /**< The 2006 draft sACN standard version. */
+  kSacnStandardVersionPublished, /**< The current published sACN standard version. */
+  kSacnStandardVersionAll        /**< Both the current published and 2006 draft sACN standard version. */
 } sacn_standard_version_t;
 
-/*!
- * \brief The default expired notification wait time.
+/**
+ * @brief The default expired notification wait time.
  *
  * Also referred to as a "hold last look" time, the default amount of time the library will wait
  * after a universe enters a data loss condition before calling the sources_lost() callback. Can be
@@ -83,66 +83,66 @@ typedef enum
  */
 #define SACN_DEFAULT_EXPIRED_WAIT_MS 1000u
 
-/*! Information about a remote sACN source being tracked by a receiver. */
+/** Information about a remote sACN source being tracked by a receiver. */
 typedef struct SacnRemoteSource
 {
-  /*! The Component Identifier (CID) of the source. */
+  /** The Component Identifier (CID) of the source. */
   EtcPalUuid cid;
-  /*! The name of the source. */
+  /** The name of the source. */
   char name[SACN_SOURCE_NAME_MAX_LEN];
 } SacnRemoteSource;
 
-/*! Information about a sACN source that was found. */
+/** Information about a sACN source that was found. */
 typedef struct SacnFoundSource
 {
-  /*! The Component Identifier (CID) of the source. */
+  /** The Component Identifier (CID) of the source. */
   EtcPalUuid cid;
-  /*! The name of the source. */
+  /** The name of the source. */
   char name[SACN_SOURCE_NAME_MAX_LEN];
-  /*! The address from which we received these initial packets. */
+  /** The address from which we received these initial packets. */
   EtcPalSockAddr from_addr;
-  /*! The per-universe priority. */
+  /** The per-universe priority. */
   uint8_t priority;
-  /*! The DMX (startcode 0) data. The library owns this data, and the memory is only guaranteed to be valid for the
+  /** The DMX (startcode 0) data. The library owns this data, and the memory is only guaranteed to be valid for the
    * length of the SacnSourcesFound callback. */
   const uint8_t* values;
-  /*! The count of valid values. */
+  /** The count of valid values. */
   size_t values_len;
-  /*! Whether or not we only saw startcode 0 packets with the preview flag set. */
+  /** Whether or not we only saw startcode 0 packets with the preview flag set. */
   bool preview;
-  /*! The per-address priority (startcode 0xdd) data, if the source is sending it. The library owns this data, and the
+  /** The per-address priority (startcode 0xdd) data, if the source is sending it. The library owns this data, and the
    * memory is only guaranteed to be valid for the length of the SacnSourcesFound callback.  */
   const uint8_t* per_addres;
-  /*! The count of valid priorities. */
+  /** The count of valid priorities. */
   size_t per_address_len;
 } SacnFoundSource;
 
-/*! Information about a sACN source that was lost. */
+/** Information about a sACN source that was lost. */
 typedef struct SacnLostSource
 {
-  /*! The Component Identifier (CID) of the source. */
+  /** The Component Identifier (CID) of the source. */
   EtcPalUuid cid;
-  /*! The name of the source. */
+  /** The name of the source. */
   char name[SACN_SOURCE_NAME_MAX_LEN];
-  /*! Whether the source was determined to be lost due to the Stream_Terminated bit being set in the
+  /** Whether the source was determined to be lost due to the Stream_Terminated bit being set in the
    *  sACN data packet. */
   bool terminated;
 } SacnLostSource;
 
-/*!
- * \name sACN receiver flags
+/**
+ * @name sACN receiver flags
  * Valid values for the flags member in the SacnReceiverConfig struct.
  * @{
  */
-/*! Filter preview data. If set, any sACN data with the Preview flag set will be dropped for this
+/** Filter preview data. If set, any sACN data with the Preview flag set will be dropped for this
  *  universe but sources sending only Preview data will still trigger a SacnSourcesFoundCallback(). */
 #define SACN_RECEIVER_OPTS_FILTER_PREVIEW_DATA 0x1
-/*!
+/**
  * @}
  */
 
-/*!
- * \brief Notify that one or more sources have been found.
+/**
+ * @brief Notify that one or more sources have been found.
  *
  * New sources have been found that can fit in the current collection.  The DMX data and per-address priorities for each
  * source may be acted upon immediately, as the library has determined the correct starting values.  Additionally, the
@@ -152,18 +152,18 @@ typedef struct SacnLostSource
  * In the rare case where the source is only sending preview packets and SACN_RECEIVER_OPTS_FILTER_PREVIEW_DATA is set,
  * this callback will be be called with a SacnFoundSource structure with 'values_len' set to 0 and 'preview' set to true.
  *
- * \param[in] handle Handle to the receiver instance for which sources were found.
- * \param[in] universe The universe number this receiver is monitoring.
- * \param[in] found_sources Array of structs describing the source or sources that have been found with their current
+ * @param[in] handle Handle to the receiver instance for which sources were found.
+ * @param[in] universe The universe number this receiver is monitoring.
+ * @param[in] found_sources Array of structs describing the source or sources that have been found with their current
  * values.
- * \param[in] num_sources_found Size of the found_sources array.
- * \param[in] context Context pointer that was given at the creation of the receiver instance.
+ * @param[in] num_sources_found Size of the found_sources array.
+ * @param[in] context Context pointer that was given at the creation of the receiver instance.
  */
 typedef void (*SacnSourcesFoundCallback)(sacn_receiver_t handle, uint16_t universe,
                                          const SacnFoundSource* found_sources, size_t num_found_sources, void* context);
 
-/*!
- * \brief Notify that a data packet has been received.
+/**
+ * @brief Notify that a data packet has been received.
  *
  * Will be called for every sACN data packet received on a listening universe for a found source, unless the
  * Stream_Terminated bit is set or if preview packets are being filtered.
@@ -176,52 +176,52 @@ typedef void (*SacnSourcesFoundCallback)(sacn_receiver_t handle, uint16_t univer
  * if the source forces the packet, or if the source sends a data packet without a sync universe.
  * TODO: this version of the sACN library does not support sACN Sync. This paragraph will be valid in the future.
  *
- * \param[in] handle Handle to the receiver instance for which universe data was received.
- * \param[in] universe The universe this receiver is monitoring.
- * \param[in] source_addr The network address from which the sACN packet originated.
- * \param[in] header The header data of the sACN packet.
- * \param[in] pdata Pointer to the data buffer. Size of the buffer is indicated by header->slot_count.
- * \param[in] context Context pointer that was given at the creation of the receiver instance.
+ * @param[in] handle Handle to the receiver instance for which universe data was received.
+ * @param[in] universe The universe this receiver is monitoring.
+ * @param[in] source_addr The network address from which the sACN packet originated.
+ * @param[in] header The header data of the sACN packet.
+ * @param[in] pdata Pointer to the data buffer. Size of the buffer is indicated by header->slot_count.
+ * @param[in] context Context pointer that was given at the creation of the receiver instance.
  */
 typedef void (*SacnUniverseDataCallback)(sacn_receiver_t handle, uint16_t universe, const EtcPalSockAddr* source_addr,
                                          const SacnHeaderData* header, const uint8_t* pdata, void* context);
 
-/*!
- * \brief Notify that one or more sources have entered a data loss state.
+/**
+ * @brief Notify that one or more sources have entered a data loss state.
  *
  * This could be due to timeout or explicit termination. Sources are grouped using an algorithm
  * designed to prevent level jumps when multiple sources are lost simultaneously. See
- * \ref data_loss_behavior for more information.
+ * @ref data_loss_behavior for more information.
  *
- * \param[in] handle Handle to the receiver instance for which sources were lost.
- * \param[in] universe The universe this receiver is monitoring.
- * \param[in] lost_sources Array of structs describing the source or sources that have been lost.
- * \param[in] num_lost_sources Size of the lost_sources array.
- * \param[in] context Context pointer that was given at the creation of the receiver instance.
+ * @param[in] handle Handle to the receiver instance for which sources were lost.
+ * @param[in] universe The universe this receiver is monitoring.
+ * @param[in] lost_sources Array of structs describing the source or sources that have been lost.
+ * @param[in] num_lost_sources Size of the lost_sources array.
+ * @param[in] context Context pointer that was given at the creation of the receiver instance.
  */
 typedef void (*SacnSourcesLostCallback)(sacn_receiver_t handle, uint16_t universe, const SacnLostSource* lost_sources,
                                         size_t num_lost_sources, void* context);
 
-/*!
- * \brief Notify that a source has stopped transmission of per-address priority packets.
+/**
+ * @brief Notify that a source has stopped transmission of per-address priority packets.
  *
  * If #SACN_ETC_PRIORITY_EXTENSION was defined to 0 when sACN was compiled, this callback will
  * never be called and may be set to NULL. This is only called due to a timeout condition; a
  * termination bit is treated as the termination of the entire stream and will result in a
  * sources_lost() notification.
  *
- * \param[in] handle Handle to the receiver instance for which a source stopped sending per-address
+ * @param[in] handle Handle to the receiver instance for which a source stopped sending per-address
  *                   priority.
- * \param[in] universe The universe this receiver is monitoring.
- * \param[in] source Information about the source that has stopped transmission of per-address
+ * @param[in] universe The universe this receiver is monitoring.
+ * @param[in] source Information about the source that has stopped transmission of per-address
  *                   priority.
- * \param[in] context Context pointer that was given at the creation of the receiver instance.
+ * @param[in] context Context pointer that was given at the creation of the receiver instance.
  */
 typedef void (*SacnSourcePapLostCallback)(sacn_receiver_t handle, uint16_t universe, const SacnRemoteSource* source,
                                           void* context);
 
-/*!
- * \brief Notify that more than the configured maximum number of sources are currently sending on
+/**
+ * @brief Notify that more than the configured maximum number of sources are currently sending on
  *        the universe being listened to.
  *
  * If #SACN_DYNAMIC_MEM was defined to 1 when sACN was compiled (the default on non-embedded
@@ -235,44 +235,44 @@ typedef void (*SacnSourcePapLostCallback)(sacn_receiver_t handle, uint16_t unive
  * from a source beyond the limit specified. After that, it will not be called again until the number of sources sending
  * drops below that limit and then hits it again.
  *
- * \param[in] handle Handle to the receiver instance for which the source limit has been exceeded.
- * \param[in] universe The universe this receiver is monitoring.
- * \param[in] context Context pointer that was given at the creation of the receiver instance.
+ * @param[in] handle Handle to the receiver instance for which the source limit has been exceeded.
+ * @param[in] universe The universe this receiver is monitoring.
+ * @param[in] context Context pointer that was given at the creation of the receiver instance.
  */
 typedef void (*SacnSourceLimitExceededCallback)(sacn_receiver_t handle, uint16_t universe, void* context);
 
-/*! A set of callback functions that the library uses to notify the application about sACN events. */
+/** A set of callback functions that the library uses to notify the application about sACN events. */
 typedef struct SacnRecvCallbacks
 {
-  SacnSourcesFoundCallback sources_found;                /*!< Required */
-  SacnUniverseDataCallback universe_data;                /*!< Required */
-  SacnSourcesLostCallback sources_lost;                  /*!< Required */
-  SacnSourcePapLostCallback source_pap_lost;             /*!< Optional */
-  SacnSourceLimitExceededCallback source_limit_exceeded; /*!< Optional */
-  void* context; /*!< (optional) Pointer to opaque data passed back with each callback. */
+  SacnSourcesFoundCallback sources_found;                /**< Required */
+  SacnUniverseDataCallback universe_data;                /**< Required */
+  SacnSourcesLostCallback sources_lost;                  /**< Required */
+  SacnSourcePapLostCallback source_pap_lost;             /**< Optional */
+  SacnSourceLimitExceededCallback source_limit_exceeded; /**< Optional */
+  void* context; /**< (optional) Pointer to opaque data passed back with each callback. */
 } SacnReceiverCallbacks;
 
-/*! A set of configuration information for an sACN receiver. */
+/** A set of configuration information for an sACN receiver. */
 typedef struct SacnReceiverConfig
 {
   /********* Required values **********/
 
-  /*! Universe number on which to listen for sACN. */
+  /** Universe number on which to listen for sACN. */
   uint16_t universe_id;
-  /*! The callbacks this receiver will use to notify the application of events. */
+  /** The callbacks this receiver will use to notify the application of events. */
   SacnReceiverCallbacks callbacks;
 
   /********* Optional values **********/
 
-  /*! The maximum number of sources this universe will listen to.  May be #SACN_RECEIVER_INFINITE_SOURCES.
+  /** The maximum number of sources this universe will listen to.  May be #SACN_RECEIVER_INFINITE_SOURCES.
       This parameter is ignored when configured to use static memory -- #SACN_RECEIVER_MAX_SOURCES_PER_UNIVERSE is used
      instead.*/
   size_t source_count_max;
-  /*! A set of option flags. See "sACN receiver flags". */
+  /** A set of option flags. See "sACN receiver flags". */
   unsigned int flags;
 } SacnReceiverConfig;
 
-/*! A default-value initializer for an SacnReceiverConfig struct. */
+/** A default-value initializer for an SacnReceiverConfig struct. */
 #define SACN_RECEIVER_CONFIG_DEFAULT_INIT                  \
   {                                                        \
     0, {NULL, NULL, NULL, NULL, NULL, NULL}, 0, 0,         \
@@ -297,7 +297,7 @@ uint32_t sacn_receiver_get_expired_wait();
 }
 #endif
 
-/*!
+/**
  * @}
  */
 

--- a/include/sacn/receiver.h
+++ b/include/sacn/receiver.h
@@ -285,12 +285,12 @@ typedef struct SacnReceiverConfig
 
 void sacn_receiver_config_init(SacnReceiverConfig* config);
 
-etcpal_error_t sacn_receiver_create(const SacnReceiverConfig* config, sacn_receiver_t* handle);
+etcpal_error_t sacn_receiver_create(const SacnReceiverConfig* config, sacn_receiver_t* handle, SacnNetworkChangeResult* good_interfaces);
 etcpal_error_t sacn_receiver_destroy(sacn_receiver_t handle);
 etcpal_error_t sacn_receiver_get_universe(sacn_receiver_t handle, uint16_t* universe_id);
 etcpal_error_t sacn_receiver_change_universe(sacn_receiver_t handle, uint16_t new_universe_id);
 etcpal_error_t sacn_receiver_reset_networking(sacn_receiver_t handle, const SacnMcastNetintId* netints,
-                                              size_t num_netints);
+                                              size_t num_netints, SacnNetworkChangeResult* good_interfaces);
 
 void sacn_receiver_set_standard_version(sacn_standard_version_t version);
 sacn_standard_version_t sacn_receiver_get_standard_version();

--- a/include/sacn/source.h
+++ b/include/sacn/source.h
@@ -151,11 +151,10 @@ void sacn_source_destroy(sacn_source_t handle);
 
 etcpal_error_t sacn_source_change_name(sacn_source_t handle, const char* new_name);
 
-etcpal_error_t sacn_source_add_universe(sacn_source_t handle, const SacnSourceUniverseConfig* config, bool dirty_now);
+etcpal_error_t sacn_source_add_universe(sacn_source_t handle, const SacnSourceUniverseConfig* config);
 void sacn_source_remove_universe(sacn_source_t handle, uint16_t universe);
 
-etcpal_error_t sacn_source_add_unicast_destination(sacn_source_t handle, uint16_t universe, const EtcPalIpAddr* dest,
-                                                   bool dirty_now);
+etcpal_error_t sacn_source_add_unicast_destination(sacn_source_t handle, uint16_t universe, const EtcPalIpAddr* dest);
 void sacn_source_remove_unicast_destination(sacn_source_t handle, uint16_t universe, const EtcPalIpAddr* dest);
 
 etcpal_error_t sacn_source_change_priority(sacn_source_t handle, uint16_t universe, uint8_t new_priority);

--- a/include/sacn/source.h
+++ b/include/sacn/source.h
@@ -122,8 +122,8 @@ typedef struct SacnSourceUniverseConfig
       If this is NULL, only the priority will be used.
       If non-NULL, this buffer is evaluated each tick.  Changes to and from 0 ("don't care") cause appropriate
       sacn packets over time to take and give control of those DMX values as defined in the per-address priority
-     specification. The memory is owned by the application, and should not be destroyed until after the universe is
-     deleted on this source. The size of this buffer must match the size of values_buffer.  */
+      specification. The memory is owned by the application, and should not be destroyed until after the universe is
+      deleted on this source. The size of this buffer must match the size of values_buffer.  */
   const uint8_t* priority_buffer;  // Priority buffer will always be checked first., then priority, then slots processed
 
   /*! If true, this sACN source is sending preview data. Defaults to false. */
@@ -131,12 +131,16 @@ typedef struct SacnSourceUniverseConfig
 
   /*! If true, this sACN source is sending unicast traffic only on this universe. Defaults to false. */
   bool send_unicast_only;
+
+  /*! If non-zero, this is the synchronization universe used to synchronize the sACN output. Defaults to 0. */
+  uint16_t sync_universe;
+
 } SacnSourceUniverseConfig;
 
 /*! A default-value initializer for an SacnSourceUniverseConfig struct. */
 #define SACN_SOURCE_UNIVERSE_CONFIG_DEFAULT_INIT \
   {                                              \
-    0, NULL, 0, 100, NULL, 0, 0                   \
+    0, NULL, 0, 100, NULL, 0, 0, 0               \
   }
 
 void sacn_source_universe_config_init(SacnSourceUniverseConfig* config, uint16_t universe, const uint8_t* values_buffer,
@@ -151,23 +155,26 @@ etcpal_error_t sacn_source_change_name(sacn_source_t handle, const char* new_nam
 etcpal_error_t sacn_source_add_universe(sacn_source_t handle, const SacnSourceUniverseConfig* config, bool dirty_now);
 void sacn_source_remove_universe(sacn_source_t handle, uint16_t universe);
 
-etcpal_error_t sacn_source_add_unicast_destination(sacn_source_t handle, uint16_t universe, const EtcPalIpAddr* dest, bool dirty_now);
+etcpal_error_t sacn_source_add_unicast_destination(sacn_source_t handle, uint16_t universe, const EtcPalIpAddr* dest,
+                                                   bool dirty_now);
 void sacn_source_remove_unicast_destination(sacn_source_t handle, uint16_t universe, const EtcPalIpAddr* dest);
 
 etcpal_error_t sacn_source_change_priority(sacn_source_t handle, uint16_t universe, uint8_t new_priority);
 etcpal_error_t sacn_source_change_preview_flag(sacn_source_t handle, uint16_t universe, bool new_preview_flag);
+etcpal_error_t sacn_source_change_synchronization_universe(sacn_source_t handle, uint16_t universe,
+                                                           uint16_t new_sync_universe);
 
 etcpal_error_t sacn_source_send_now(sacn_source_t handle, uint16_t universe, uint8_t start_code, const uint8_t* buffer,
                                     size_t buflen);
+etcpal_error_t sacn_source_send_synchronization(sacn_source_t handle, uint16_t universe);
 
 void sacn_source_set_dirty(sacn_source_t handle, uint8_t universe);
 void sacn_source_set_list_dirty(sacn_source_t handle, uint8_t* universes, size_t num_universes);
+void sacn_source_set_dirty_and_force_sync(sacn_source_t handle, uint8_t universe);
 
 size_t sacn_source_process_sources(void);
 
 etcpal_error_t sacn_source_reset_networking(sacn_source_t handle, const SacnMcastNetintId* netints, size_t num_netints);
-
-// NB-W TESTING TODO DRAFT????
 
 #ifdef __cplusplus
 }

--- a/include/sacn/source.h
+++ b/include/sacn/source.h
@@ -79,8 +79,8 @@ typedef struct SacnSourceConfig
       This parameter is ignored when configured to use static memory -- #SACN_SOURCE_MAX_UNIVERSES is used instead.*/
   size_t universe_count_max;
 
-  /** If false (default), this module starts a thread that calls sacn_source_process_sources() every 23 ms.
-      If true, no thread is started and the application must call sacn_source_process_sources() at its DMX rate,
+  /** If false (default), this module starts a shared thread that calls sacn_source_process_all() every 23 ms.
+      If true, no thread is started and the application must call sacn_source_process_all() at its DMX rate,
       usually 23 ms. */
   bool manually_process_source;
 
@@ -89,7 +89,7 @@ typedef struct SacnSourceConfig
 /** A default-value initializer for an SacnSourceConfig struct. */
 #define SACN_SOURCE_CONFIG_DEFAULT_INIT \
   {                                     \
-    kEtcPalNullUuid, "", 0, 0           \
+    kEtcPalNullUuid, "", 0, false       \
   }
 
 void sacn_source_config_init(SacnSourceConfig* config, const EtcPalUuid* cid, const char* name);
@@ -121,10 +121,10 @@ typedef struct SacnSourceUniverseConfig
       deleted on this source. The size of this buffer must match the size of values_buffer.  */
   const uint8_t* priorities_buffer; 
 
-  /** If true, this sACN source is sending preview data. Defaults to false. */
-  bool sending_preview;
+  /** If true, this sACN source will send preview data. Defaults to false. */
+  bool send_preview;
 
-  /** If true, this sACN source is only sending unicast traffic on this universe. Defaults to false. */
+  /** If true, this sACN source will only send unicast traffic on this universe. Defaults to false. */
   bool send_unicast_only;
 
   /** If non-zero, this is the synchronization universe used to synchronize the sACN output. Defaults to 0. */
@@ -135,7 +135,7 @@ typedef struct SacnSourceUniverseConfig
 /** A default-value initializer for an SacnSourceUniverseConfig struct. */
 #define SACN_SOURCE_UNIVERSE_CONFIG_DEFAULT_INIT \
   {                                              \
-    0, NULL, 0, 100, NULL, 0, 0, 0               \
+    0, NULL, 0, 100, NULL, false, false, 0       \
   }
 
 void sacn_source_universe_config_init(SacnSourceUniverseConfig* config, uint16_t universe, const uint8_t* values_buffer,
@@ -166,7 +166,7 @@ void sacn_source_set_dirty(sacn_source_t handle, uint16_t universe);
 void sacn_source_set_list_dirty(sacn_source_t handle, const uint16_t* universes, size_t num_universes);
 void sacn_source_set_dirty_and_force_sync(sacn_source_t handle, uint16_t universe);
 
-size_t sacn_source_process_sources(void);
+size_t sacn_source_process_all(void);
 
 etcpal_error_t sacn_source_reset_networking(sacn_source_t handle, SacnMcastInterface* netints, size_t num_netints);
 

--- a/include/sacn/source.h
+++ b/include/sacn/source.h
@@ -79,7 +79,7 @@ typedef struct SacnSourceConfig
       This parameter is ignored when configured to use static memory -- #SACN_SOURCE_MAX_UNIVERSES is used
      instead.*/
   size_t universe_count_max;
-  /*! (optional) array of network interfaces on which to listen to the specified universe. If NULL,
+  /*! (optional) array of network interfaces on which to send to the specified universe. If NULL,
    *  all available network interfaces will be used. */
   const SacnMcastNetintId* netints;
   /*! Number of elements in the netints array. */
@@ -88,7 +88,7 @@ typedef struct SacnSourceConfig
   /*! If false (default), this module starts a thread that calls sacn_source_process_sources() every 23 ms.
       If true, no thread is started and the application must call sacn_source_process_sources() at its DMX rate,
       usually 23 ms. */
-  bool manual_process;
+  bool manually_process_source;
 
 } SacnSourceConfig;
 

--- a/include/sacn/source.h
+++ b/include/sacn/source.h
@@ -110,10 +110,10 @@ typedef struct SacnSourceUniverseConfig
 
   /********* Optional values **********/
 
-  /** The sACN priority that is sent in each packet. This is only allowed to be from 0 - 200. Defaults to 100. */
+  /** The sACN universe priority that is sent in each packet. This is only allowed to be from 0 - 200. Defaults to 100. */
   uint8_t priority;
   /** The (optional) buffer of up to 512 per-address priorities that will be sent each tick.
-      If this is NULL, only the priority will be used.
+      If this is NULL, only the universe priority will be used.
       If non-NULL, this buffer is evaluated each tick.  Changes to and from 0 ("don't care") cause appropriate
       sacn packets over time to take and give control of those DMX values as defined in the per-address priority
       specification.
@@ -166,7 +166,7 @@ void sacn_source_set_dirty(sacn_source_t handle, uint16_t universe);
 void sacn_source_set_list_dirty(sacn_source_t handle, const uint16_t* universes, size_t num_universes);
 void sacn_source_set_dirty_and_force_sync(sacn_source_t handle, uint16_t universe);
 
-size_t sacn_source_process_all(void);
+int sacn_source_process_all(void);
 
 etcpal_error_t sacn_source_reset_networking(sacn_source_t handle, SacnMcastInterface* netints, size_t num_netints);
 

--- a/include/sacn/source.h
+++ b/include/sacn/source.h
@@ -75,7 +75,7 @@ typedef struct SacnSourceConfig
 
   /********* Optional values **********/
 
-  /*! The maximum number of sources this universe will send to.  May be #SACN_SOURCE_INFINITE_UNIVERSES.
+  /*! The maximum number of universes this source will send to.  May be #SACN_SOURCE_INFINITE_UNIVERSES.
       This parameter is ignored when configured to use static memory -- #SACN_SOURCE_MAX_UNIVERSES is used
      instead.*/
   size_t universe_count_max;
@@ -167,9 +167,9 @@ etcpal_error_t sacn_source_send_now(sacn_source_t handle, uint16_t universe, uin
                                     size_t buflen);
 etcpal_error_t sacn_source_send_synchronization(sacn_source_t handle, uint16_t universe);
 
-void sacn_source_set_dirty(sacn_source_t handle, uint8_t universe);
-void sacn_source_set_list_dirty(sacn_source_t handle, uint8_t* universes, size_t num_universes);
-void sacn_source_set_dirty_and_force_sync(sacn_source_t handle, uint8_t universe);
+void sacn_source_set_dirty(sacn_source_t handle, uint16_t universe);
+void sacn_source_set_list_dirty(sacn_source_t handle, const uint16_t* universes, size_t num_universes);
+void sacn_source_set_dirty_and_force_sync(sacn_source_t handle, uint16_t universe);
 
 size_t sacn_source_process_sources(void);
 

--- a/include/sacn/source.h
+++ b/include/sacn/source.h
@@ -98,7 +98,7 @@ typedef struct SacnSourceUniverseConfig
 {
   /********* Required values **********/
 
-  /** The universe number, At this time, only values from 1 - 63999 are accepted.
+  /** The universe number. At this time, only values from 1 - 63999 are accepted.
       You cannot have a source send more than one stream of values to a single universe. */
   uint16_t universe;
   /** The buffer of up to 512 dmx values that will be sent each tick.

--- a/include/sacn/source.h
+++ b/include/sacn/source.h
@@ -142,7 +142,7 @@ void sacn_source_universe_config_init(SacnSourceUniverseConfig* config, uint16_t
                                       size_t values_len, const uint8_t* priorities_buffer);
 
 etcpal_error_t sacn_source_create(const SacnSourceConfig* config, sacn_source_t* handle,
-                                  SacnMcastInterfaceToUse* ifaces, size_t ifaces_count);
+                                  SacnMcastInterface* netints, size_t num_netints);
 void sacn_source_destroy(sacn_source_t handle);
 
 etcpal_error_t sacn_source_change_name(sacn_source_t handle, const char* new_name);
@@ -168,7 +168,7 @@ void sacn_source_set_dirty_and_force_sync(sacn_source_t handle, uint16_t univers
 
 size_t sacn_source_process_sources(void);
 
-etcpal_error_t sacn_source_reset_networking(sacn_source_t handle, SacnMcastInterfaceToUse* ifaces, size_t ifaces_count);
+etcpal_error_t sacn_source_reset_networking(sacn_source_t handle, SacnMcastInterface* netints, size_t num_netints);
 
 #ifdef __cplusplus
 }

--- a/include/sacn/source.h
+++ b/include/sacn/source.h
@@ -79,11 +79,6 @@ typedef struct SacnSourceConfig
       This parameter is ignored when configured to use static memory -- #SACN_SOURCE_MAX_UNIVERSES is used
      instead.*/
   size_t universe_count_max;
-  /*! (optional) array of network interfaces on which to send to the specified universe. If NULL,
-   *  all available network interfaces will be used. */
-  const SacnMcastNetintId* netints;
-  /*! Number of elements in the netints array. */
-  size_t num_netints;
 
   /*! If false (default), this module starts a thread that calls sacn_source_process_sources() every 23 ms.
       If true, no thread is started and the application must call sacn_source_process_sources() at its DMX rate,
@@ -95,7 +90,7 @@ typedef struct SacnSourceConfig
 /*! A default-value initializer for an SacnSourceConfig struct. */
 #define SACN_SOURCE_CONFIG_DEFAULT_INIT \
   {                                     \
-    kEtcPalNullUuid, "", 0, NULL, 0, 0  \
+    kEtcPalNullUuid, "", 0, 0           \
   }
 
 void sacn_source_config_init(SacnSourceConfig* config, const EtcPalUuid* cid, const char* name);
@@ -122,9 +117,10 @@ typedef struct SacnSourceUniverseConfig
       If this is NULL, only the priority will be used.
       If non-NULL, this buffer is evaluated each tick.  Changes to and from 0 ("don't care") cause appropriate
       sacn packets over time to take and give control of those DMX values as defined in the per-address priority
-      specification. The memory is owned by the application, and should not be destroyed until after the universe is
+      specification.
+      The memory is owned by the application, and should not be destroyed until after the universe is
       deleted on this source. The size of this buffer must match the size of values_buffer.  */
-  const uint8_t* priorities_buffer;  // Priorities buffer will always be checked first., then priority, then slots processed
+  const uint8_t* priorities_buffer; 
 
   /*! If true, this sACN source is sending preview data. Defaults to false. */
   bool sending_preview;
@@ -146,7 +142,8 @@ typedef struct SacnSourceUniverseConfig
 void sacn_source_universe_config_init(SacnSourceUniverseConfig* config, uint16_t universe, const uint8_t* values_buffer,
                                       size_t values_len, const uint8_t* priorities_buffer);
 
-etcpal_error_t sacn_source_create(const SacnSourceConfig* config, sacn_source_t* handle, SacnNetworkChangeResult* good_interfaces);
+etcpal_error_t sacn_source_create(const SacnSourceConfig* config, sacn_source_t* handle,
+                                  SacnMcastInterfaceToUse* ifaces, size_t ifaces_count);
 void sacn_source_destroy(sacn_source_t handle);
 
 etcpal_error_t sacn_source_change_name(sacn_source_t handle, const char* new_name);
@@ -172,7 +169,7 @@ void sacn_source_set_dirty_and_force_sync(sacn_source_t handle, uint16_t univers
 
 size_t sacn_source_process_sources(void);
 
-etcpal_error_t sacn_source_reset_networking(sacn_source_t handle, const SacnMcastNetintId* netints, size_t num_netints, SacnNetworkChangeResult* good_interfaces);
+etcpal_error_t sacn_source_reset_networking(sacn_source_t handle, SacnMcastInterfaceToUse* ifaces, size_t ifaces_count);
 
 #ifdef __cplusplus
 }

--- a/include/sacn/source.h
+++ b/include/sacn/source.h
@@ -55,42 +55,68 @@ typedef int sacn_source_t;
 /*! An invalid sACN source handle value. */
 #define SACN_SOURCE_INVALID -1
 
-typedef struct SacnStartCodeConfig
-{
-  uint8_t start_code;
-  bool always_send;
-  uint8_t* slot_buffer;
-  size_t num_slots;
-} SacnStartCodeConfig;
+/*!
+ * \brief Constant for "infinite" when sending sACN universes.
+ *
+ * When using dynamic memory, this constant can be passed in when creating a source.
+ * It represents an infinite number of universes that can be sent to.
+ */
+#define SACN_SOURCE_INFINITE_UNIVERSES 0
 
+/*! A set of configuration information for a sACN source. */
 typedef struct SacnSourceConfig
 {
-  /* Required configuration data */
+  /********* Required values **********/
   EtcPalUuid cid;
-  uint16_t universe_id;
-
-  /* Optional configuration data */
-  uint8_t priority;
-  const SacnMcastNetintId* netints;
-  size_t num_netints;
-  bool preview;
   char name[SACN_SOURCE_NAME_MAX_LEN];
+
+  /********* Optional values **********/
+
+  /*! The maximum number of sources this universe will send to.  May be #SACN_SOURCE_INFINITE_UNIVERSES.
+      This parameter is ignored when configured to use static memory -- #SACN_SOURCE_MAX_UNIVERSES is used
+     instead.*/
+  size_t source_count_max;
+  /*! (optional) array of network interfaces on which to listen to the specified universe. If NULL,
+   *  all available network interfaces will be used. */
+  const SacnMcastNetintId* netints;
+  /*! Number of elements in the netints array. */
+  size_t num_netints;
 } SacnSourceConfig;
 
-typedef struct SacnSourceStartCodePair
+typedef struct SacnSourceUniverseConfig
 {
-  sacn_source_t handle;
-  uint8_t start_code;
-} SacnSourceStartCodePair;
+  /********* Required values **********/
+  uint16_t universe_id;
+  uint8_t* slot_buffer;  //Values??
+  size_t num_slots;
+
+  /********* Optional values **********/
+  uint8_t priority;
+  uint8_t* priority_buffer;  //Priority buffer will always be checked first., then priority, then slots processed
+  size_t num_priorities;  //???
+
+  /*! A set of option flags. See "sACN receiver flags". */
+  unsigned int flags; //PREVIEW??
+
+} SacnSourceUniverseConfig;
 
 void sacn_source_config_set_defaults(SacnSourceConfig* config);
+void sacn_source_universe_config_set_defaults(SacnSourceUniverseConfig* config);
 
 etcpal_error_t sacn_source_create(const SacnSourceConfig* config, sacn_source_t* handle);
 etcpal_error_t sacn_source_destroy(sacn_source_t handle);
 
+sacn_source_add_universe; //Starts universe discovery, starts data/priority/per-address
+sacn_source_remove_universe;  //Gracefully shutds down universe (sending values properly), stops universe discovery.
+
+sacn_source_send_non_dmx;  //alternate start code stuff
+
+
+//Instead of adding start codes, have a data/priority section for a handle, and allow sending of other start codes manually?
 etcpal_error_t sacn_source_add_start_code(sacn_source_t handle, const SacnStartCodeConfig* sc_config);
 etcpal_error_t sacn_source_remove_start_code(sacn_source_t handle, uint8_t start_code);
 
+//NOT SURE WE NEED THESE, or changing priority/per-addresssssss.. Maybe so..
 etcpal_error_t sacn_source_change_priority(sacn_source_t handle, uint8_t new_priority);
 etcpal_error_t sacn_source_change_preview_flag(sacn_source_t handle, bool new_preview_flag);
 etcpal_error_t sacn_source_change_name(sacn_source_t handle, const char* new_name);
@@ -99,6 +125,10 @@ void sacn_source_set_dirty(sacn_source_t handle, uint8_t start_code);
 void sacn_sources_set_dirty(const SacnSourceStartCodePair* start_codes, size_t num_start_codes);
 void sacn_source_send_now(sacn_source_t handle, uint8_t start_code);
 void sacn_sources_send_now(const SacnSourceStartCodePair* start_codes, size_t num_start_codes);
+
+etcpal_error_t sacn_source_reset_networking(sacn_receiver_t handle, const SacnMcastNetintId* netints,
+                                              size_t num_netints);
+//What about multiple sources for same universe??
 
 size_t sacn_process_sources(void);
 

--- a/include/sacn/source.h
+++ b/include/sacn/source.h
@@ -17,11 +17,11 @@
  * https://github.com/ETCLabs/sACN
  *****************************************************************************/
 
-/*!
- * \file sacn/source.h
- * \brief sACN Source API definitions
+/**
+ * @file sacn/source.h
+ * @brief sACN Source API definitions
  *
- * Functions and definitions for the \ref sacn_source "sACN Source API" are contained in this
+ * Functions and definitions for the @ref sacn_source "sACN Source API" are contained in this
  * header.
  */
 
@@ -36,10 +36,10 @@
 #include "etcpal/uuid.h"
 #include "sacn/common.h"
 
-/*!
- * \defgroup sacn_source sACN Source
- * \ingroup sACN
- * \brief The sACN Source API.
+/**
+ * @defgroup sacn_source sACN Source
+ * @ingroup sACN
+ * @brief The sACN Source API.
  *
  * Components that send sACN are referred to as sACN Sources. Use this API to act as an sACN Source.
  *
@@ -50,44 +50,43 @@
 extern "C" {
 #endif
 
-/*! A handle to a sACN source. */
+/** A handle to a sACN source. */
 typedef int sacn_source_t;
-/*! An invalid sACN source handle value. */
+/** An invalid sACN source handle value. */
 #define SACN_SOURCE_INVALID -1
 
-/*!
- * \brief Constant for "infinite" when sending sACN universes.
+/**
+ * @brief Constant for "infinite" when sending sACN universes.
  *
  * When using dynamic memory, this constant can be passed in when creating a source.
  * It represents an infinite number of universes that can be sent to.
  */
 #define SACN_SOURCE_INFINITE_UNIVERSES 0
 
-/*! A set of configuration information for a sACN source. */
+/** A set of configuration information for a sACN source. */
 typedef struct SacnSourceConfig
 {
   /********* Required values **********/
 
-  /*! The source's CID. */
+  /** The source's CID. */
   EtcPalUuid cid;
-  /*! The source's name, a UTF-8 encoded string. */
+  /** The source's name, a UTF-8 encoded string. */
   char name[SACN_SOURCE_NAME_MAX_LEN];
 
   /********* Optional values **********/
 
-  /*! The maximum number of universes this source will send to.  May be #SACN_SOURCE_INFINITE_UNIVERSES.
-      This parameter is ignored when configured to use static memory -- #SACN_SOURCE_MAX_UNIVERSES is used
-     instead.*/
+  /** The maximum number of universes this source will send to.  May be #SACN_SOURCE_INFINITE_UNIVERSES.
+      This parameter is ignored when configured to use static memory -- #SACN_SOURCE_MAX_UNIVERSES is used instead.*/
   size_t universe_count_max;
 
-  /*! If false (default), this module starts a thread that calls sacn_source_process_sources() every 23 ms.
+  /** If false (default), this module starts a thread that calls sacn_source_process_sources() every 23 ms.
       If true, no thread is started and the application must call sacn_source_process_sources() at its DMX rate,
       usually 23 ms. */
   bool manually_process_source;
 
 } SacnSourceConfig;
 
-/*! A default-value initializer for an SacnSourceConfig struct. */
+/** A default-value initializer for an SacnSourceConfig struct. */
 #define SACN_SOURCE_CONFIG_DEFAULT_INIT \
   {                                     \
     kEtcPalNullUuid, "", 0, 0           \
@@ -99,21 +98,21 @@ typedef struct SacnSourceUniverseConfig
 {
   /********* Required values **********/
 
-  /*! The universe number, At this time, only values from 1 - 63999 are accepted.
+  /** The universe number, At this time, only values from 1 - 63999 are accepted.
       You cannot have a source send more than one stream of values to a single universe. */
   uint16_t universe;
-  /*! The buffer of up to 512 dmx values that will be sent each tick.
+  /** The buffer of up to 512 dmx values that will be sent each tick.
       This pointer may not be NULL. The memory is owned by the application, and should not
       be destroyed until after the universe is deleted on this source. */
   const uint8_t* values_buffer;
-  /*! The size of values_buffer. */
+  /** The size of values_buffer. */
   size_t num_values;
 
   /********* Optional values **********/
 
-  /*! The sACN priority that is sent in each packet. This is only allowed to be from 0 - 200. Defaults to 100. */
+  /** The sACN priority that is sent in each packet. This is only allowed to be from 0 - 200. Defaults to 100. */
   uint8_t priority;
-  /*! The (optional) buffer of up to 512 per-address priorities that will be sent each tick.
+  /** The (optional) buffer of up to 512 per-address priorities that will be sent each tick.
       If this is NULL, only the priority will be used.
       If non-NULL, this buffer is evaluated each tick.  Changes to and from 0 ("don't care") cause appropriate
       sacn packets over time to take and give control of those DMX values as defined in the per-address priority
@@ -122,18 +121,18 @@ typedef struct SacnSourceUniverseConfig
       deleted on this source. The size of this buffer must match the size of values_buffer.  */
   const uint8_t* priorities_buffer; 
 
-  /*! If true, this sACN source is sending preview data. Defaults to false. */
+  /** If true, this sACN source is sending preview data. Defaults to false. */
   bool sending_preview;
 
-  /*! If true, this sACN source is only sending unicast traffic on this universe. Defaults to false. */
+  /** If true, this sACN source is only sending unicast traffic on this universe. Defaults to false. */
   bool send_unicast_only;
 
-  /*! If non-zero, this is the synchronization universe used to synchronize the sACN output. Defaults to 0. */
+  /** If non-zero, this is the synchronization universe used to synchronize the sACN output. Defaults to 0. */
   uint16_t sync_universe;
 
 } SacnSourceUniverseConfig;
 
-/*! A default-value initializer for an SacnSourceUniverseConfig struct. */
+/** A default-value initializer for an SacnSourceUniverseConfig struct. */
 #define SACN_SOURCE_UNIVERSE_CONFIG_DEFAULT_INIT \
   {                                              \
     0, NULL, 0, 100, NULL, 0, 0, 0               \
@@ -175,7 +174,7 @@ etcpal_error_t sacn_source_reset_networking(sacn_source_t handle, SacnMcastInter
 }
 #endif
 
-/*!
+/**
  * @}
  */
 

--- a/include/sacn/source.h
+++ b/include/sacn/source.h
@@ -129,7 +129,7 @@ typedef struct SacnSourceUniverseConfig
   /*! If true, this sACN source is sending preview data. Defaults to false. */
   bool sending_preview;
 
-  /*! If true, this sACN source is sending unicast traffic only on this universe. Defaults to false. */
+  /*! If true, this sACN source is only sending unicast traffic on this universe. Defaults to false. */
   bool send_unicast_only;
 
   /*! If non-zero, this is the synchronization universe used to synchronize the sACN output. Defaults to 0. */
@@ -151,7 +151,6 @@ void sacn_source_destroy(sacn_source_t handle);
 
 etcpal_error_t sacn_source_change_name(sacn_source_t handle, const char* new_name);
 
-// NB-W TESTING TODO: Interface failure??
 etcpal_error_t sacn_source_add_universe(sacn_source_t handle, const SacnSourceUniverseConfig* config, bool dirty_now);
 void sacn_source_remove_universe(sacn_source_t handle, uint16_t universe);
 

--- a/include/sacn/source.h
+++ b/include/sacn/source.h
@@ -124,7 +124,7 @@ typedef struct SacnSourceUniverseConfig
       sacn packets over time to take and give control of those DMX values as defined in the per-address priority
       specification. The memory is owned by the application, and should not be destroyed until after the universe is
       deleted on this source. The size of this buffer must match the size of values_buffer.  */
-  const uint8_t* priority_buffer;  // Priority buffer will always be checked first., then priority, then slots processed
+  const uint8_t* priorities_buffer;  // Priorities buffer will always be checked first., then priority, then slots processed
 
   /*! If true, this sACN source is sending preview data. Defaults to false. */
   bool sending_preview;
@@ -144,7 +144,7 @@ typedef struct SacnSourceUniverseConfig
   }
 
 void sacn_source_universe_config_init(SacnSourceUniverseConfig* config, uint16_t universe, const uint8_t* values_buffer,
-                                      size_t values_len, const uint8_t* priority_buffer);
+                                      size_t values_len, const uint8_t* priorities_buffer);
 
 etcpal_error_t sacn_source_create(const SacnSourceConfig* config, sacn_source_t* handle, SacnNetworkChangeResult* good_interfaces);
 void sacn_source_destroy(sacn_source_t handle);

--- a/include/sacn/source.h
+++ b/include/sacn/source.h
@@ -146,7 +146,7 @@ typedef struct SacnSourceUniverseConfig
 void sacn_source_universe_config_init(SacnSourceUniverseConfig* config, uint16_t universe, const uint8_t* values_buffer,
                                       size_t values_len, const uint8_t* priority_buffer);
 
-etcpal_error_t sacn_source_create(const SacnSourceConfig* config, sacn_source_t* handle);
+etcpal_error_t sacn_source_create(const SacnSourceConfig* config, sacn_source_t* handle, SacnNetworkChangeResult* good_interfaces);
 void sacn_source_destroy(sacn_source_t handle);
 
 etcpal_error_t sacn_source_change_name(sacn_source_t handle, const char* new_name);
@@ -174,7 +174,7 @@ void sacn_source_set_dirty_and_force_sync(sacn_source_t handle, uint8_t universe
 
 size_t sacn_source_process_sources(void);
 
-etcpal_error_t sacn_source_reset_networking(sacn_source_t handle, const SacnMcastNetintId* netints, size_t num_netints);
+etcpal_error_t sacn_source_reset_networking(sacn_source_t handle, const SacnMcastNetintId* netints, size_t num_netints, SacnNetworkChangeResult* good_interfaces);
 
 #ifdef __cplusplus
 }

--- a/include/sacn/version.h
+++ b/include/sacn/version.h
@@ -17,9 +17,9 @@
  * https://github.com/ETCLabs/sACN
  *****************************************************************************/
 
-/*!
- * \file sacn/version.h
- * \brief Provides the current version of the sACN library.
+/**
+ * @file sacn/version.h
+ * @brief Provides the current version of the sACN library.
  *
  * This file is provided for application use; the values defined in this file are not used
  * internally by the library.
@@ -30,36 +30,36 @@
 
 /* clang-format off */
 
-/*!
- * \addtogroup sACN
+/**
+ * @addtogroup sACN
  * @{
  */
 
-/*!
- * \name sACN version numbers
+/**
+ * @name sACN version numbers
  * @{
  */
-#define SACN_VERSION_MAJOR 2 /*!< The major version. */
-#define SACN_VERSION_MINOR 0 /*!< The minor version. */
-#define SACN_VERSION_PATCH 0 /*!< The patch version. */
-#define SACN_VERSION_BUILD 2 /*!< The build number. */
-/*!
+#define SACN_VERSION_MAJOR 2 /**< The major version. */
+#define SACN_VERSION_MINOR 0 /**< The minor version. */
+#define SACN_VERSION_PATCH 0 /**< The patch version. */
+#define SACN_VERSION_BUILD 2 /**< The build number. */
+/**
  * @}
  */
 
-/*!
- * \name sACN version strings
+/**
+ * @name sACN version strings
  * @{
  */
 #define SACN_VERSION_STRING      "2.0.0.2"
 #define SACN_VERSION_DATESTR     "05.May.2020"
 #define SACN_VERSION_COPYRIGHT   "Copyright 2020 ETC Inc."
 #define SACN_VERSION_PRODUCTNAME "sACN"
-/*!
+/**
  * @}
  */
 
-/*!
+/**
  * @}
  */
 

--- a/src/sacn/common.c
+++ b/src/sacn/common.c
@@ -74,7 +74,6 @@ etcpal_error_t sacn_init(const EtcPalLogParams* log_params)
     bool data_loss_initted = false;
     bool receiver_initted = false;
     bool source_initted = false;
-    //TODO DRAFT SOURCE
     bool merger_initted = false;
     bool merge_receiver_initted = false;
 

--- a/src/sacn/common.c
+++ b/src/sacn/common.c
@@ -48,16 +48,16 @@ static etcpal_mutex_t sacn_mutex;
 
 /*************************** Function definitions ****************************/
 
-/*!
- * \brief Initialize the sACN library.
+/**
+ * @brief Initialize the sACN library.
  *
  * Do all necessary initialization before other sACN API functions can be called.
  *
- * \param[in] log_params A struct used by the library to log messages, or NULL for no logging. If
+ * @param[in] log_params A struct used by the library to log messages, or NULL for no logging. If
  *                       #SACN_LOGGING_ENABLED is 0, this parameter is ignored.
- * \return #kEtcPalErrOk: Initialization successful.
- * \return #kEtcPalErrInvalid: Invalid parameter provided.
- * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ * @return #kEtcPalErrOk: Initialization successful.
+ * @return #kEtcPalErrInvalid: Invalid parameter provided.
+ * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
 etcpal_error_t sacn_init(const EtcPalLogParams* log_params)
 {
@@ -140,8 +140,8 @@ etcpal_error_t sacn_init(const EtcPalLogParams* log_params)
   return res;
 }
 
-/*!
- * \brief Deinitialize the sACN library.
+/**
+ * @brief Deinitialize the sACN library.
  *
  * Set the sACN library back to an uninitialized state. Calls to other sACN API functions will fail
  * until sacn_init() is called again.

--- a/src/sacn/dmx_merger.c
+++ b/src/sacn/dmx_merger.c
@@ -148,19 +148,19 @@ void sacn_dmx_merger_deinit(void)
   }
 }
 
-/*!
- * \brief Create a new merger instance.
+/**
+ * @brief Create a new merger instance.
  *
  * Creates a new merger that uses the passed in config data.  The application owns all buffers
  * in the config, so be sure to call dmx_merger_destroy before destroying the buffers.
  *
- * \param[in] config Configuration parameters for the DMX merger to be created.
- * \param[out] handle Filled in on success with a handle to the merger.
- * \return #kEtcPalErrOk: Merger created successfully.
- * \return #kEtcPalErrInvalid: Invalid parameter provided.
- * \return #kEtcPalErrNotInit: Module not initialized.
- * \return #kEtcPalErrNoMem: No room to allocate memory for this merger, or maximum number of mergers has been reached.
- * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ * @param[in] config Configuration parameters for the DMX merger to be created.
+ * @param[out] handle Filled in on success with a handle to the merger.
+ * @return #kEtcPalErrOk: Merger created successfully.
+ * @return #kEtcPalErrInvalid: Invalid parameter provided.
+ * @return #kEtcPalErrNotInit: Module not initialized.
+ * @return #kEtcPalErrNoMem: No room to allocate memory for this merger, or maximum number of mergers has been reached.
+ * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
 etcpal_error_t sacn_dmx_merger_create(const SacnDmxMergerConfig* config, sacn_dmx_merger_t* handle)
 {
@@ -219,16 +219,16 @@ etcpal_error_t sacn_dmx_merger_create(const SacnDmxMergerConfig* config, sacn_dm
   return result;
 }
 
-/*!
- * \brief Destroy a merger instance.
+/**
+ * @brief Destroy a merger instance.
  *
  * Tears down the merger and cleans up its resources.
  *
- * \param[in] handle Handle to the merger to destroy.
- * \return #kEtcPalErrOk: Merger destroyed successfully.
- * \return #kEtcPalErrNotInit: Module not initialized.
- * \return #kEtcPalErrNotFound: Handle does not correspond to a valid merger.
- * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ * @param[in] handle Handle to the merger to destroy.
+ * @return #kEtcPalErrOk: Merger destroyed successfully.
+ * @return #kEtcPalErrNotInit: Module not initialized.
+ * @return #kEtcPalErrNotFound: Handle does not correspond to a valid merger.
+ * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
 etcpal_error_t sacn_dmx_merger_destroy(sacn_dmx_merger_t handle)
 {
@@ -293,8 +293,8 @@ etcpal_error_t sacn_dmx_merger_destroy(sacn_dmx_merger_t handle)
   return result;
 }
 
-/*!
- * \brief Adds a new source to the merger.
+/**
+ * @brief Adds a new source to the merger.
  *
  * Adds a new source to the merger, if the maximum number of sources hasn't been reached.
  * The filled in source id is used for two purposes:
@@ -302,15 +302,15 @@ etcpal_error_t sacn_dmx_merger_destroy(sacn_dmx_merger_t handle)
  *   - It is the source identifer that is put into the slot_owners buffer that was passed
  *     in the DmxMergerUniverseConfig structure when creating the merger.
  *
- * \param[in] merger The handle to the merger.
- * \param[in] source_cid The sACN CID of the source.
- * \param[out] source_id Filled in on success with the source id.
- * \return #kEtcPalErrOk: Source added successfully.
- * \return #kEtcPalErrInvalid: Invalid parameter provided.
- * \return #kEtcPalErrNotInit: Module not initialized.
- * \return #kEtcPalErrNoMem: No room to allocate memory for this source, or the max number of sources has been reached.
- * \return #kEtcPalErrExists: the source at that cid was already added.
- * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ * @param[in] merger The handle to the merger.
+ * @param[in] source_cid The sACN CID of the source.
+ * @param[out] source_id Filled in on success with the source id.
+ * @return #kEtcPalErrOk: Source added successfully.
+ * @return #kEtcPalErrInvalid: Invalid parameter provided.
+ * @return #kEtcPalErrNotInit: Module not initialized.
+ * @return #kEtcPalErrNoMem: No room to allocate memory for this source, or the max number of sources has been reached.
+ * @return #kEtcPalErrExists: the source at that cid was already added.
+ * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
 etcpal_error_t sacn_dmx_merger_add_source(sacn_dmx_merger_t merger, const EtcPalUuid* source_cid,
                                           sacn_source_id_t* source_id)
@@ -432,17 +432,17 @@ etcpal_error_t sacn_dmx_merger_add_source(sacn_dmx_merger_t merger, const EtcPal
   return result;
 }
 
-/*!
- * \brief Removes a source from the merger.
+/**
+ * @brief Removes a source from the merger.
  *
  * Removes the source from the merger.  This causes the merger to recalculate the outputs.
  *
- * \param[in] merger The handle to the merger.
- * \param[in] source The id of the source to remove.
- * \return #kEtcPalErrOk: Source removed successfully.
- * \return #kEtcPalErrInvalid: Invalid parameter provided.
- * \return #kEtcPalErrNotInit: Module not initialized.
- * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ * @param[in] merger The handle to the merger.
+ * @param[in] source The id of the source to remove.
+ * @return #kEtcPalErrOk: Source removed successfully.
+ * @return #kEtcPalErrInvalid: Invalid parameter provided.
+ * @return #kEtcPalErrNotInit: Module not initialized.
+ * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
 etcpal_error_t sacn_dmx_merger_remove_source(sacn_dmx_merger_t merger, sacn_source_id_t source)
 {
@@ -520,12 +520,12 @@ etcpal_error_t sacn_dmx_merger_remove_source(sacn_dmx_merger_t merger, sacn_sour
   return result;
 }
 
-/*!
- * \brief Returns the source id for that source cid.
+/**
+ * @brief Returns the source id for that source cid.
  *
- * \param[in] merger The handle to the merger.
- * \param[in] source_cid The UUID of the source CID.
- * \return The source ID, or #SACN_DMX_MERGER_SOURCE_INVALID.
+ * @param[in] merger The handle to the merger.
+ * @param[in] source_cid The UUID of the source CID.
+ * @return The source ID, or #SACN_DMX_MERGER_SOURCE_INVALID.
  */
 sacn_source_id_t sacn_dmx_merger_get_id(sacn_dmx_merger_t merger, const EtcPalUuid* source_cid)
 {
@@ -540,16 +540,16 @@ sacn_source_id_t sacn_dmx_merger_get_id(sacn_dmx_merger_t merger, const EtcPalUu
   return result;
 }
 
-/*!
- * \brief Gets a read-only view of the source data.
+/**
+ * @brief Gets a read-only view of the source data.
  *
  * Looks up the source data and returns a pointer to the data or NULL if it doesn't exist.
  * This pointer is owned by the library, and must not be modified by the application.
  * The pointer will only be valid until the source or merger is removed.
  *
- * \param[in] merger The handle to the merger.
- * \param[in] source The id of the source.
- * \return The pointer to the source data, or NULL if the source wasn't found.
+ * @param[in] merger The handle to the merger.
+ * @param[in] source The id of the source.
+ * @return The pointer to the source data, or NULL if the source wasn't found.
  */
 const SacnDmxMergerSource* sacn_dmx_merger_get_source(sacn_dmx_merger_t merger, sacn_source_id_t source)
 {
@@ -576,26 +576,26 @@ const SacnDmxMergerSource* sacn_dmx_merger_get_source(sacn_dmx_merger_t merger, 
   return result;
 }
 
-/*!
- * \brief Updates the source data and recalculate outputs.
+/**
+ * @brief Updates the source data and recalculate outputs.
  *
  * The direct method to change source data.  This causes the merger to recalculate the outputs.
  * If you are processing sACN packets, you may prefer dmx_merger_update_source_from_sacn().
  *
- * \param[in] merger The handle to the merger.
- * \param[in] source The id of the source to modify.
- * \param[in] priority The universe-level priority of the source.
- * \param[in] new_values The new DMX values to be copied in. this must be NULL if the source is not updating DMX data.
- * \param[in] new_values_count The length of new_values. Must be 0 if the source is not updating DMX data.
- * \param[in] address_priorities The per-address priority values to be copied in.  This must be NULL if the source is
+ * @param[in] merger The handle to the merger.
+ * @param[in] source The id of the source to modify.
+ * @param[in] priority The universe-level priority of the source.
+ * @param[in] new_values The new DMX values to be copied in. this must be NULL if the source is not updating DMX data.
+ * @param[in] new_values_count The length of new_values. Must be 0 if the source is not updating DMX data.
+ * @param[in] address_priorities The per-address priority values to be copied in.  This must be NULL if the source is
  * not updating per-address priority data.
- * \param[in] address_priorities_count The length of address_priorities.  Must be 0 if the source is not updating
+ * @param[in] address_priorities_count The length of address_priorities.  Must be 0 if the source is not updating
  * per-address priority data.
- * \return #kEtcPalErrOk: Source updated and merge completed.
- * \return #kEtcPalErrInvalid: Invalid parameter provided.
- * \return #kEtcPalErrNotInit: Module not initialized.
- * \return #kEtcPalErrNotFound: Handle does not correspond to a valid source or merger.
- * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ * @return #kEtcPalErrOk: Source updated and merge completed.
+ * @return #kEtcPalErrInvalid: Invalid parameter provided.
+ * @return #kEtcPalErrNotInit: Module not initialized.
+ * @return #kEtcPalErrNotFound: Handle does not correspond to a valid source or merger.
+ * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
 etcpal_error_t sacn_dmx_merger_update_source_data(sacn_dmx_merger_t merger, sacn_source_id_t source, uint8_t priority,
                                                   const uint8_t* new_values, size_t new_values_count,
@@ -672,21 +672,21 @@ etcpal_error_t sacn_dmx_merger_update_source_data(sacn_dmx_merger_t merger, sacn
   return result;
 }
 
-/*!
- * \brief Updates the source data from a sACN packet and recalculate outputs.
+/**
+ * @brief Updates the source data from a sACN packet and recalculate outputs.
  *
  * Processes data passed from the sACN receiver's SacnUniverseDataCallback() handler.  This causes the merger to
  * recalculate the outputs.
  *
- * \param[in] merger The handle to the merger.
- * \param[in] header The sACN header.  Must NOT be NULL.
- * \param[in] pdata The sACN data.
- * \return #kEtcPalErrOk: Source updated and merge completed.
- * \return #kEtcPalErrInvalid: Invalid parameter provided.
- * \return #kEtcPalErrNotInit: Module not initialized.
- * \return #kEtcPalErrNotFound: Handle does not correspond to a valid merger, or source CID in the header doesn't match
+ * @param[in] merger The handle to the merger.
+ * @param[in] header The sACN header.  Must NOT be NULL.
+ * @param[in] pdata The sACN data.
+ * @return #kEtcPalErrOk: Source updated and merge completed.
+ * @return #kEtcPalErrInvalid: Invalid parameter provided.
+ * @return #kEtcPalErrNotInit: Module not initialized.
+ * @return #kEtcPalErrNotFound: Handle does not correspond to a valid merger, or source CID in the header doesn't match
  * a known source.
- * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
 etcpal_error_t sacn_dmx_merger_update_source_from_sacn(sacn_dmx_merger_t merger, const SacnHeaderData* header,
                                                        const uint8_t* pdata)
@@ -768,19 +768,19 @@ etcpal_error_t sacn_dmx_merger_update_source_from_sacn(sacn_dmx_merger_t merger,
   return result;
 }
 
-/*!
- * \brief Removes the per-address data from the source and recalculate outputs.
+/**
+ * @brief Removes the per-address data from the source and recalculate outputs.
  *
  * Per-address priority data can time out in sACN just like values.
  * This is a convenience function to immediately turn off the per-address priority data for a source and recalculate the
  * outputs.
  *
- * \param[in] merger The handle to the merger.
- * \param[in] source The id of the source to modify.
- * \return #kEtcPalErrOk: Source updated and merge completed.
- * \return #kEtcPalErrNotFound: Handle does not correspond to a valid source or merger.
- * \return #kEtcPalErrNotInit: Module not initialized.
- * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ * @param[in] merger The handle to the merger.
+ * @param[in] source The id of the source to modify.
+ * @return #kEtcPalErrOk: Source updated and merge completed.
+ * @return #kEtcPalErrNotFound: Handle does not correspond to a valid source or merger.
+ * @return #kEtcPalErrNotInit: Module not initialized.
+ * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
 etcpal_error_t sacn_dmx_merger_stop_source_per_address_priority(sacn_dmx_merger_t merger, sacn_source_id_t source)
 {

--- a/src/sacn/merge_receiver.c
+++ b/src/sacn/merge_receiver.c
@@ -149,7 +149,7 @@ void sacn_merge_receiver_config_init(SacnMergeReceiverConfig* config)
  *
  * \param[in] config Configuration parameters for the sACN Merge Receiver to be created.
  * \param[out] handle Filled in on success with a handle to the sACN Merge Receiver.
- * \param[in, out] good_interfaces Optional. If non-NULL, good_interfaces is filled in with the list of network
+ * \param[out] good_interfaces Optional. If non-NULL, good_interfaces is filled in with the list of network
  * interfaces that were succesfully used.
  * \return #kEtcPalErrOk: Merge Receiver created successfully.
  * \return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.
@@ -250,7 +250,7 @@ etcpal_error_t sacn_merge_receiver_change_universe(sacn_merge_receiver_t handle,
  * \param[in] (optional) array of network interfaces on which to listen to the specified universe. If NULL,
  *  all available network interfaces will be used.
  * \param[in] Number of elements in the netints array.
- * \param[in, out] good_interfaces Optional. If non-NULL, good_interfaces is filled in with the list of network
+ * \param[in] good_interfaces Optional. If non-NULL, good_interfaces is filled in with the list of network
  * interfaces that were succesfully used.
  * \return #kEtcPalErrOk: Network reset successfully.
  * \return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.

--- a/src/sacn/merge_receiver.c
+++ b/src/sacn/merge_receiver.c
@@ -143,19 +143,29 @@ void sacn_merge_receiver_config_init(SacnMergeReceiverConfig* config)
  * An sACN merge receiver can listen on one universe at a time, and each universe can only be listened to
  * by one merge receiver at at time.
  *
+ * Note that a merge receiver is considered as successfully created if it is able to successfully use any of the
+ * network interfaces listed in the passed in configuration.  This will only return #kEtcPalErrNoNetints
+ * if none of the interfaces work.
+ *
  * \param[in] config Configuration parameters for the sACN Merge Receiver to be created.
  * \param[out] handle Filled in on success with a handle to the sACN Merge Receiver.
+ * \param[in, out] good_interfaces Optional. If non-NULL, good_interfaces is filled in with the list of network
+ * interfaces that were succesfully used.
  * \return #kEtcPalErrOk: Merge Receiver created successfully.
+ * \return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.
  * \return #kEtcPalErrInvalid: Invalid parameter provided.
  * \return #kEtcPalErrNotInit: Module not initialized.
  * \return #kEtcPalErrExists: A merge receiver already exists which is listening on the specified universe.
  * \return #kEtcPalErrNoMem: No room to allocate memory for this merge receiver, or maximum merge receivers reached.
- * \return #kEtcPalErrNoNetints: No network interfaces were found on the system.
  * \return #kEtcPalErrNotFound: A network interface ID given was not found on the system.
  * \return #kEtcPalErrSys: An internal library or system call error occurred.
  */
-etcpal_error_t sacn_merge_receiver_create(const SacnMergeReceiverConfig* config, sacn_merge_receiver_t* handle)
+etcpal_error_t sacn_merge_receiver_create(const SacnMergeReceiverConfig* config, sacn_merge_receiver_t* handle,
+                                          SacnNetworkChangeResult* good_interfaces)
 {
+  //TODO CHRISTIAN
+  ETCPAL_UNUSED_ARG(good_interfaces);
+
   // CHRISTIAN TODO
   if (!config || !handle)
     return kEtcPalErrInvalid;
@@ -233,23 +243,30 @@ etcpal_error_t sacn_merge_receiver_change_universe(sacn_merge_receiver_t handle,
  * this call fails, the caller must call sacn_merge_receiver_destroy for the merge receiver, because the receiver may be
  * in an invalid state.
  *
+ * Note that the networking reset is considered successful if it is able to successfully use any of the
+ * network interfaces passed in.  This will only return #kEtcPalErrNoNetints if none of the interfaces work.
+ *
  * \param[in] handle Handle to the merge receiver for which to reset the networking.
  * \param[in] (optional) array of network interfaces on which to listen to the specified universe. If NULL,
  *  all available network interfaces will be used.
  * \param[in] Number of elements in the netints array.
+ * \param[in, out] good_interfaces Optional. If non-NULL, good_interfaces is filled in with the list of network
+ * interfaces that were succesfully used.
  * \return #kEtcPalErrOk: Network reset successfully.
+ * \return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.
  * \return #kEtcPalErrInvalid: Invalid parameter provided.
  * \return #kEtcPalErrNotInit: Module not initialized.
  * \return #kEtcPalErrNotFound: Handle does not correspond to a valid merge receiver.
  * \return #kEtcPalErrSys: An internal library or system call error occurred.
  */
 etcpal_error_t sacn_merge_receiver_reset_networking(sacn_merge_receiver_t handle, const SacnMcastNetintId* netints,
-                                                    size_t num_netints)
+                                                    size_t num_netints, SacnNetworkChangeResult* good_interfaces)
 {
   // TODO CHRISTIAN CLEANUP
   ETCPAL_UNUSED_ARG(handle);
   ETCPAL_UNUSED_ARG(netints);
   ETCPAL_UNUSED_ARG(num_netints);
+  ETCPAL_UNUSED_ARG(good_interfaces);
   return kEtcPalErrNotImpl;
 }
 

--- a/src/sacn/merge_receiver.c
+++ b/src/sacn/merge_receiver.c
@@ -124,10 +124,10 @@ void sacn_merge_receiver_deinit(void)
   */
 }
 
-/*!
- * \brief Initialize an sACN Merge Receiver Config struct to default values.
+/**
+ * @brief Initialize an sACN Merge Receiver Config struct to default values.
  *
- * \param[out] config Config struct to initialize.
+ * @param[out] config Config struct to initialize.
  */
 void sacn_merge_receiver_config_init(SacnMergeReceiverConfig* config)
 {
@@ -137,8 +137,8 @@ void sacn_merge_receiver_config_init(SacnMergeReceiverConfig* config)
   }
 }
 
-/*!
- * \brief Create a new sACN Merge Receiver to listen and merge sACN data on a universe.
+/**
+ * @brief Create a new sACN Merge Receiver to listen and merge sACN data on a universe.
  *
  * An sACN merge receiver can listen on one universe at a time, and each universe can only be listened to
  * by one merge receiver at at time.
@@ -147,19 +147,19 @@ void sacn_merge_receiver_config_init(SacnMergeReceiverConfig* config)
  * network interfaces listed in the passed in.  This will only return #kEtcPalErrNoNetints
  * if none of the interfaces work.
  *
- * \param[in] config Configuration parameters for the sACN Merge Receiver to be created.
- * \param[out] handle Filled in on success with a handle to the sACN Merge Receiver.
- * \param[in, out] ifaces Optional. If non-NULL, this is the list of interfaces the application wants to use, and the
+ * @param[in] config Configuration parameters for the sACN Merge Receiver to be created.
+ * @param[out] handle Filled in on success with a handle to the sACN Merge Receiver.
+ * @param[in, out] ifaces Optional. If non-NULL, this is the list of interfaces the application wants to use, and the
  * operation_succeeded flags are filled in.  If NULL, all available interfaces are tried.
- * \param[in, out] ifaces_count Optional. The size of ifaces, or 0 if ifaces is NULL.
- * \return #kEtcPalErrOk: Merge Receiver created successfully.
- * \return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.
- * \return #kEtcPalErrInvalid: Invalid parameter provided.
- * \return #kEtcPalErrNotInit: Module not initialized.
- * \return #kEtcPalErrExists: A merge receiver already exists which is listening on the specified universe.
- * \return #kEtcPalErrNoMem: No room to allocate memory for this merge receiver, or maximum merge receivers reached.
- * \return #kEtcPalErrNotFound: A network interface ID given was not found on the system.
- * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ * @param[in, out] ifaces_count Optional. The size of ifaces, or 0 if ifaces is NULL.
+ * @return #kEtcPalErrOk: Merge Receiver created successfully.
+ * @return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.
+ * @return #kEtcPalErrInvalid: Invalid parameter provided.
+ * @return #kEtcPalErrNotInit: Module not initialized.
+ * @return #kEtcPalErrExists: A merge receiver already exists which is listening on the specified universe.
+ * @return #kEtcPalErrNoMem: No room to allocate memory for this merge receiver, or maximum merge receivers reached.
+ * @return #kEtcPalErrNotFound: A network interface ID given was not found on the system.
+ * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
 etcpal_error_t sacn_merge_receiver_create(const SacnMergeReceiverConfig* config, sacn_merge_receiver_t* handle,
                                           SacnMcastInterfaceToUse* ifaces, size_t ifaces_count)
@@ -175,14 +175,14 @@ etcpal_error_t sacn_merge_receiver_create(const SacnMergeReceiverConfig* config,
   return kEtcPalErrNotImpl;
 }
 
-/*!
- * \brief Destroy a sACN Merge Receiver instance.
+/**
+ * @brief Destroy a sACN Merge Receiver instance.
  *
- * \param[in] handle Handle to the merge receiver to destroy.
- * \return #kEtcPalErrOk: Merge receiver destroyed successfully.
- * \return #kEtcPalErrNotInit: Module not initialized.
- * \return #kEtcPalErrNotFound: Handle does not correspond to a valid merge receiver.
- * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ * @param[in] handle Handle to the merge receiver to destroy.
+ * @return #kEtcPalErrOk: Merge receiver destroyed successfully.
+ * @return #kEtcPalErrNotInit: Module not initialized.
+ * @return #kEtcPalErrNotFound: Handle does not correspond to a valid merge receiver.
+ * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
 etcpal_error_t sacn_merge_receiver_destroy(sacn_merge_receiver_t handle)
 {
@@ -191,16 +191,16 @@ etcpal_error_t sacn_merge_receiver_destroy(sacn_merge_receiver_t handle)
   return kEtcPalErrNotImpl;
 }
 
-/*!
- * \brief Get the universe on which a sACN Merge Receiver is currently listening.
+/**
+ * @brief Get the universe on which a sACN Merge Receiver is currently listening.
  *
- * \param[in] handle Handle to the merge receiver that we want to query.
- * \param[out] universe_id The retrieved universe.
- * \return #kEtcPalErrOk: Universe retrieved successfully.
- * \return #kEtcPalErrInvalid: Invalid parameter provided.
- * \return #kEtcPalErrNotInit: Module not initialized.
- * \return #kEtcPalErrNotFound: Handle does not correspond to a valid merge receiver.
- * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ * @param[in] handle Handle to the merge receiver that we want to query.
+ * @param[out] universe_id The retrieved universe.
+ * @return #kEtcPalErrOk: Universe retrieved successfully.
+ * @return #kEtcPalErrInvalid: Invalid parameter provided.
+ * @return #kEtcPalErrNotInit: Module not initialized.
+ * @return #kEtcPalErrNotFound: Handle does not correspond to a valid merge receiver.
+ * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
 etcpal_error_t sacn_merge_receiver_get_universe(sacn_merge_receiver_t handle, uint16_t* universe_id)
 {
@@ -210,21 +210,21 @@ etcpal_error_t sacn_merge_receiver_get_universe(sacn_merge_receiver_t handle, ui
   return kEtcPalErrNotImpl;
 }
 
-/*!
- * \brief Change the universe on which a sACN Merge Receiver is listening.
+/**
+ * @brief Change the universe on which a sACN Merge Receiver is listening.
  *
  * An sACN merge receiver can only listen on one universe at a time. After this call completes, underlying updates will
  * generate new calls to SacnMergeReceiverMergedDataCallback(). If this call fails, the caller must call
  * sacn_merge_receiver_destroy for the merge receiver, because the merge receiver may be in an invalid state.
  *
- * \param[in] handle Handle to the merge receiver for which to change the universe.
- * \param[in] new_universe_id New universe number that this merge receiver should listen to.
- * \return #kEtcPalErrOk: Universe changed successfully.
- * \return #kEtcPalErrInvalid: Invalid parameter provided.
- * \return #kEtcPalErrNotInit: Module not initialized.
- * \return #kEtcPalErrExists: A merge receiver already exists which is listening on the specified new universe.
- * \return #kEtcPalErrNotFound: Handle does not correspond to a valid merge receiver.
- * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ * @param[in] handle Handle to the merge receiver for which to change the universe.
+ * @param[in] new_universe_id New universe number that this merge receiver should listen to.
+ * @return #kEtcPalErrOk: Universe changed successfully.
+ * @return #kEtcPalErrInvalid: Invalid parameter provided.
+ * @return #kEtcPalErrNotInit: Module not initialized.
+ * @return #kEtcPalErrExists: A merge receiver already exists which is listening on the specified new universe.
+ * @return #kEtcPalErrNotFound: Handle does not correspond to a valid merge receiver.
+ * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
 etcpal_error_t sacn_merge_receiver_change_universe(sacn_merge_receiver_t handle, uint16_t new_universe_id)
 {
@@ -236,8 +236,8 @@ etcpal_error_t sacn_merge_receiver_change_universe(sacn_merge_receiver_t handle,
   return kEtcPalErrNotImpl;
 }
 
-/*!
- * \brief Resets the underlying network sockets and packet receipt state for the sACN Merge Receiver.
+/**
+ * @brief Resets the underlying network sockets and packet receipt state for the sACN Merge Receiver.
  *
  * This is typically used when the application detects that the list of networking interfaces has changed.
  *
@@ -248,16 +248,16 @@ etcpal_error_t sacn_merge_receiver_change_universe(sacn_merge_receiver_t handle,
  * Note that the networking reset is considered successful if it is able to successfully use any of the
  * network interfaces passed in.  This will only return #kEtcPalErrNoNetints if none of the interfaces work.
  *
- * \param[in] handle Handle to the merge receiver for which to reset the networking.
- * \param[in, out] ifaces Optional. If non-NULL, this is the list of interfaces the application wants to use, and the
+ * @param[in] handle Handle to the merge receiver for which to reset the networking.
+ * @param[in,out] ifaces Optional. If non-NULL, this is the list of interfaces the application wants to use, and the
  * operation_succeeded flags are filled in.  If NULL, all available interfaces are tried.
- * \param[in, out] ifaces_count Optional. The size of ifaces, or 0 if ifaces is NULL.
- * \return #kEtcPalErrOk: Network reset successfully.
- * \return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.
- * \return #kEtcPalErrInvalid: Invalid parameter provided.
- * \return #kEtcPalErrNotInit: Module not initialized.
- * \return #kEtcPalErrNotFound: Handle does not correspond to a valid merge receiver.
- * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ * @param[in, out] ifaces_count Optional. The size of ifaces, or 0 if ifaces is NULL.
+ * @return #kEtcPalErrOk: Network reset successfully.
+ * @return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.
+ * @return #kEtcPalErrInvalid: Invalid parameter provided.
+ * @return #kEtcPalErrNotInit: Module not initialized.
+ * @return #kEtcPalErrNotFound: Handle does not correspond to a valid merge receiver.
+ * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
 etcpal_error_t sacn_merge_receiver_reset_networking(sacn_merge_receiver_t handle, SacnMcastInterfaceToUse* ifaces,
                                                     size_t ifaces_count)
@@ -269,12 +269,12 @@ etcpal_error_t sacn_merge_receiver_reset_networking(sacn_merge_receiver_t handle
   return kEtcPalErrNotImpl;
 }
 
-/*!
- * \brief Returns the source id for that source cid.
+/**
+ * @brief Returns the source id for that source cid.
  *
- * \param[in] handle The handle to the merge receiver.
- * \param[in] source_cid The UUID of the source CID.
- * \return The source ID, or #SACN_DMX_MERGER_SOURCE_INVALID.
+ * @param[in] handle The handle to the merge receiver.
+ * @param[in] source_cid The UUID of the source CID.
+ * @return The source ID, or #SACN_DMX_MERGER_SOURCE_INVALID.
  */
 sacn_source_id_t sacn_merge_receiver_get_source_id(sacn_merge_receiver_t handle, const EtcPalUuid* source_cid)
 {
@@ -284,14 +284,14 @@ sacn_source_id_t sacn_merge_receiver_get_source_id(sacn_merge_receiver_t handle,
   return SACN_DMX_MERGER_SOURCE_INVALID;
 }
 
-/*!
- * \brief fills in the source cid for that source id.
+/**
+ * @brief fills in the source cid for that source id.
  *
- * \param[in] handle The handle to the merge receiver.
- * \param[in] source_id The ID of the source.
- * \param[out] source_cid The UUID of the source CID.
- * \return #kEtcPalErrOk: Lookup was successful.
- * \return #kEtcPalErrNotFound: handle does not correspond to a valid merge receiver, or source_id  does not correspond
+ * @param[in] handle The handle to the merge receiver.
+ * @param[in] source_id The ID of the source.
+ * @param[out] source_cid The UUID of the source CID.
+ * @return #kEtcPalErrOk: Lookup was successful.
+ * @return #kEtcPalErrNotFound: handle does not correspond to a valid merge receiver, or source_id  does not correspond
  * to a valid source.
  */
 etcpal_error_t sacn_merge_receiver_get_source_cid(sacn_merge_receiver_t handle, sacn_source_id_t source_id,

--- a/src/sacn/merge_receiver.c
+++ b/src/sacn/merge_receiver.c
@@ -144,13 +144,14 @@ void sacn_merge_receiver_config_init(SacnMergeReceiverConfig* config)
  * by one merge receiver at at time.
  *
  * Note that a merge receiver is considered as successfully created if it is able to successfully use any of the
- * network interfaces listed in the passed in configuration.  This will only return #kEtcPalErrNoNetints
+ * network interfaces listed in the passed in.  This will only return #kEtcPalErrNoNetints
  * if none of the interfaces work.
  *
  * \param[in] config Configuration parameters for the sACN Merge Receiver to be created.
  * \param[out] handle Filled in on success with a handle to the sACN Merge Receiver.
- * \param[out] good_interfaces Optional. If non-NULL, good_interfaces is filled in with the list of network
- * interfaces that were succesfully used.
+ * \param[in, out] ifaces Optional. If non-NULL, this is the list of interfaces the application wants to use, and the
+ * operation_succeeded flags are filled in.  If NULL, all available interfaces are tried.
+ * \param[in, out] ifaces_count Optional. The size of ifaces, or 0 if ifaces is NULL.
  * \return #kEtcPalErrOk: Merge Receiver created successfully.
  * \return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.
  * \return #kEtcPalErrInvalid: Invalid parameter provided.
@@ -161,10 +162,11 @@ void sacn_merge_receiver_config_init(SacnMergeReceiverConfig* config)
  * \return #kEtcPalErrSys: An internal library or system call error occurred.
  */
 etcpal_error_t sacn_merge_receiver_create(const SacnMergeReceiverConfig* config, sacn_merge_receiver_t* handle,
-                                          SacnNetworkChangeResult* good_interfaces)
+                                          SacnMcastInterfaceToUse* ifaces, size_t ifaces_count)
 {
   //TODO CHRISTIAN
-  ETCPAL_UNUSED_ARG(good_interfaces);
+  ETCPAL_UNUSED_ARG(ifaces);
+  ETCPAL_UNUSED_ARG(ifaces_count);
 
   // CHRISTIAN TODO
   if (!config || !handle)
@@ -235,7 +237,7 @@ etcpal_error_t sacn_merge_receiver_change_universe(sacn_merge_receiver_t handle,
 }
 
 /*!
- * \brief Resets the underlying network sockets and packet receipt state for the sACN Merge Receiver..
+ * \brief Resets the underlying network sockets and packet receipt state for the sACN Merge Receiver.
  *
  * This is typically used when the application detects that the list of networking interfaces has changed.
  *
@@ -247,11 +249,9 @@ etcpal_error_t sacn_merge_receiver_change_universe(sacn_merge_receiver_t handle,
  * network interfaces passed in.  This will only return #kEtcPalErrNoNetints if none of the interfaces work.
  *
  * \param[in] handle Handle to the merge receiver for which to reset the networking.
- * \param[in] (optional) array of network interfaces on which to listen to the specified universe. If NULL,
- *  all available network interfaces will be used.
- * \param[in] Number of elements in the netints array.
- * \param[in] good_interfaces Optional. If non-NULL, good_interfaces is filled in with the list of network
- * interfaces that were succesfully used.
+ * \param[in, out] ifaces Optional. If non-NULL, this is the list of interfaces the application wants to use, and the
+ * operation_succeeded flags are filled in.  If NULL, all available interfaces are tried.
+ * \param[in, out] ifaces_count Optional. The size of ifaces, or 0 if ifaces is NULL.
  * \return #kEtcPalErrOk: Network reset successfully.
  * \return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.
  * \return #kEtcPalErrInvalid: Invalid parameter provided.
@@ -259,14 +259,13 @@ etcpal_error_t sacn_merge_receiver_change_universe(sacn_merge_receiver_t handle,
  * \return #kEtcPalErrNotFound: Handle does not correspond to a valid merge receiver.
  * \return #kEtcPalErrSys: An internal library or system call error occurred.
  */
-etcpal_error_t sacn_merge_receiver_reset_networking(sacn_merge_receiver_t handle, const SacnMcastNetintId* netints,
-                                                    size_t num_netints, SacnNetworkChangeResult* good_interfaces)
+etcpal_error_t sacn_merge_receiver_reset_networking(sacn_merge_receiver_t handle, SacnMcastInterfaceToUse* ifaces,
+                                                    size_t ifaces_count)
 {
   // TODO CHRISTIAN CLEANUP
   ETCPAL_UNUSED_ARG(handle);
-  ETCPAL_UNUSED_ARG(netints);
-  ETCPAL_UNUSED_ARG(num_netints);
-  ETCPAL_UNUSED_ARG(good_interfaces);
+  ETCPAL_UNUSED_ARG(ifaces);
+  ETCPAL_UNUSED_ARG(ifaces_count);
   return kEtcPalErrNotImpl;
 }
 

--- a/src/sacn/merge_receiver.c
+++ b/src/sacn/merge_receiver.c
@@ -149,9 +149,9 @@ void sacn_merge_receiver_config_init(SacnMergeReceiverConfig* config)
  *
  * @param[in] config Configuration parameters for the sACN Merge Receiver to be created.
  * @param[out] handle Filled in on success with a handle to the sACN Merge Receiver.
- * @param[in, out] ifaces Optional. If non-NULL, this is the list of interfaces the application wants to use, and the
+ * @param[in, out] netints Optional. If non-NULL, this is the list of interfaces the application wants to use, and the
  * operation_succeeded flags are filled in.  If NULL, all available interfaces are tried.
- * @param[in, out] ifaces_count Optional. The size of ifaces, or 0 if ifaces is NULL.
+ * @param[in, out] num_netints Optional. The size of netints, or 0 if netints is NULL.
  * @return #kEtcPalErrOk: Merge Receiver created successfully.
  * @return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.
  * @return #kEtcPalErrInvalid: Invalid parameter provided.
@@ -162,11 +162,11 @@ void sacn_merge_receiver_config_init(SacnMergeReceiverConfig* config)
  * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
 etcpal_error_t sacn_merge_receiver_create(const SacnMergeReceiverConfig* config, sacn_merge_receiver_t* handle,
-                                          SacnMcastInterfaceToUse* ifaces, size_t ifaces_count)
+                                          SacnMcastInterface* netints, size_t num_netints)
 {
   //TODO CHRISTIAN
-  ETCPAL_UNUSED_ARG(ifaces);
-  ETCPAL_UNUSED_ARG(ifaces_count);
+  ETCPAL_UNUSED_ARG(netints);
+  ETCPAL_UNUSED_ARG(num_netints);
 
   // CHRISTIAN TODO
   if (!config || !handle)
@@ -249,9 +249,9 @@ etcpal_error_t sacn_merge_receiver_change_universe(sacn_merge_receiver_t handle,
  * network interfaces passed in.  This will only return #kEtcPalErrNoNetints if none of the interfaces work.
  *
  * @param[in] handle Handle to the merge receiver for which to reset the networking.
- * @param[in,out] ifaces Optional. If non-NULL, this is the list of interfaces the application wants to use, and the
+ * @param[in,out] netints Optional. If non-NULL, this is the list of interfaces the application wants to use, and the
  * operation_succeeded flags are filled in.  If NULL, all available interfaces are tried.
- * @param[in, out] ifaces_count Optional. The size of ifaces, or 0 if ifaces is NULL.
+ * @param[in, out] num_netints Optional. The size of netints, or 0 if netints is NULL.
  * @return #kEtcPalErrOk: Network reset successfully.
  * @return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.
  * @return #kEtcPalErrInvalid: Invalid parameter provided.
@@ -259,13 +259,13 @@ etcpal_error_t sacn_merge_receiver_change_universe(sacn_merge_receiver_t handle,
  * @return #kEtcPalErrNotFound: Handle does not correspond to a valid merge receiver.
  * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
-etcpal_error_t sacn_merge_receiver_reset_networking(sacn_merge_receiver_t handle, SacnMcastInterfaceToUse* ifaces,
-                                                    size_t ifaces_count)
+etcpal_error_t sacn_merge_receiver_reset_networking(sacn_merge_receiver_t handle, SacnMcastInterface* netints,
+                                                    size_t num_netints)
 {
   // TODO CHRISTIAN CLEANUP
   ETCPAL_UNUSED_ARG(handle);
-  ETCPAL_UNUSED_ARG(ifaces);
-  ETCPAL_UNUSED_ARG(ifaces_count);
+  ETCPAL_UNUSED_ARG(netints);
+  ETCPAL_UNUSED_ARG(num_netints);
   return kEtcPalErrNotImpl;
 }
 

--- a/src/sacn/private/dmx_merger.h
+++ b/src/sacn/private/dmx_merger.h
@@ -17,10 +17,10 @@
  * https://github.com/ETCLabs/sACN
  *****************************************************************************/
 
-/*!
- * \file sacn/private/dmx_merger.h
- * \brief Private constants, types, and function declarations for the
- *        \ref sacn_dmx_merger "sACN DMX Merger" module.
+/**
+ * @file sacn/private/dmx_merger.h
+ * @brief Private constants, types, and function declarations for the
+ *        @ref sacn_dmx_merger "sACN DMX Merger" module.
  */
 
 #ifndef SACN_PRIVATE_DMX_MERGER_H_

--- a/src/sacn/private/merge_receiver.h
+++ b/src/sacn/private/merge_receiver.h
@@ -17,10 +17,10 @@
  * https://github.com/ETCLabs/sACN
  *****************************************************************************/
 
-/*!
- * \file sacn/private/merge_receiver.h
- * \brief Private constants, types, and function declarations for the
- *        \ref sacn_merge_receiver "sACN Merge Receiver" module.
+/**
+ * @file sacn/private/merge_receiver.h
+ * @brief Private constants, types, and function declarations for the
+ *        @ref sacn_merge_receiver "sACN Merge Receiver" module.
  */
 
 #ifndef SACN_PRIVATE_MERGE_RECEIVER_H_

--- a/src/sacn/private/opts.h
+++ b/src/sacn/private/opts.h
@@ -17,23 +17,23 @@
  * https://github.com/ETCLabs/sACN
  *****************************************************************************/
 
-/*!
- * \file sacn/private/opts.h
- * \brief sACN configuration options.
+/**
+ * @file sacn/private/opts.h
+ * @brief sACN configuration options.
  *
- * Default values for all of sACN's \ref sacnopts "compile-time configuration options".
+ * Default values for all of sACN's @ref sacnopts "compile-time configuration options".
  */
 
 #ifndef SACN_PRIVATE_OPTS_H_
 #define SACN_PRIVATE_OPTS_H_
 
-/*!
- * \defgroup sacnopts sACN Configuration Options
- * \ingroup sACN
- * \brief Compile-time configuration options for sACN.
+/**
+ * @defgroup sacnopts sACN Configuration Options
+ * @ingroup sACN
+ * @brief Compile-time configuration options for sACN.
  *
- * Default values are indicated as the value of the \#define. Default values can be overriden by
- * defining the option in your project's `sacn_config.h` file. See \ref building_and_integrating
+ * Default values are indicated as the value of the @#define. Default values can be overriden by
+ * defining the option in your project's `sacn_config.h` file. See @ref building_and_integrating
  * for more information on the `sacn_config.h` file.
  */
 
@@ -46,7 +46,7 @@
 
 /* Some option hints based on well-known compile definitions */
 
-/*! \cond */
+/** \cond */
 
 /* Are we being compiled for a full-featured OS? */
 #if defined(_WIN32) || defined(__APPLE__) || defined(__linux__) || defined(__unix__) || defined(_POSIX_VERSION)
@@ -55,31 +55,31 @@
 #define SACN_FULL_OS_AVAILABLE_HINT 0
 #endif
 
-/*! \endcond */
+/** \endcond */
 
 /*************************** sACN Global Options *****************************/
 
-/*!
- * \defgroup sacnopts_global Global Options
- * \ingroup sacnopts
+/**
+ * @defgroup sacnopts_global Global Options
+ * @ingroup sacnopts
  *
- * Options that apply to both \ref sacn_source and \ref sacn_receiver.
+ * Options that apply to both @ref sacn_source and @ref sacn_receiver.
  * @{
  */
 
-/*!
- * \brief Use dynamic memory allocation.
+/**
+ * @brief Use dynamic memory allocation.
  *
  * If defined nonzero, sACN manages memory dynamically using malloc() and free() from stdlib.h.
- * Otherwise, sACN uses fixed-size pools through \ref etcpal_mempool. The size of the pools is
+ * Otherwise, sACN uses fixed-size pools through @ref etcpal_mempool. The size of the pools is
  * controlled with other config options.
  */
 #ifndef SACN_DYNAMIC_MEM
 #define SACN_DYNAMIC_MEM SACN_FULL_OS_AVAILABLE_HINT
 #endif
 
-/*!
- * \brief Enable message logging from the sACN library.
+/**
+ * @brief Enable message logging from the sACN library.
  *
  * If defined nonzero, the log function pointer parameter taken by sACN init functions is used to
  * log messages from the library.
@@ -88,15 +88,15 @@
 #define SACN_LOGGING_ENABLED 1
 #endif
 
-/*!
- * \brief A string which will be prepended to all log messages from the sACN library.
+/**
+ * @brief A string which will be prepended to all log messages from the sACN library.
  */
 #ifndef SACN_LOG_MSG_PREFIX
 #define SACN_LOG_MSG_PREFIX "sACN: "
 #endif
 
-/*!
- * \brief The debug assert used by the sACN library.
+/**
+ * @brief The debug assert used by the sACN library.
  *
  * By default, just uses the C library assert. If redefining this, it must be redefined as a macro
  * taking a single argument (the assertion expression).
@@ -106,10 +106,10 @@
 #define SACN_ASSERT(expr) assert(expr)
 #endif
 
-/*!
- * \brief Enable ETC's per-address priority extension to sACN.
+/**
+ * @brief Enable ETC's per-address priority extension to sACN.
  *
- * If defined nonzero, the logic of \ref sacn_receiver "sACN Receiver" changes to handle ETC's
+ * If defined nonzero, the logic of @ref sacn_receiver "sACN Receiver" changes to handle ETC's
  * per-address priority sACN extension. An additional callback function is also enabled to be
  * notified that a source has stopped sending per-address priority.
  */
@@ -117,8 +117,8 @@
 #define SACN_ETC_PRIORITY_EXTENSION 1
 #endif
 
-/*!
- * \brief Allow loopback of sACN to the local host (by setting the relevant socket option).
+/**
+ * @brief Allow loopback of sACN to the local host (by setting the relevant socket option).
  *
  * Most, but not all, platforms have this option enabled by default. This is necessary if a host
  * wants to receive the same sACN it is sending.
@@ -127,8 +127,8 @@
 #define SACN_LOOPBACK 1
 #endif
 
-/*!
- * \brief The maximum number of network interfaces that can used by the sACN library.
+/**
+ * @brief The maximum number of network interfaces that can used by the sACN library.
  *
  * Meaningful only if #SACN_DYNAMIC_MEM is defined to 0.
  */
@@ -136,22 +136,22 @@
 #define SACN_MAX_NETINTS 2
 #endif
 
-/*!
+/**
  * @}
  */
 
 /*************************** sACN Receive Options ****************************/
 
-/*!
- * \defgroup sacnopts_receiver sACN Receiver Options
- * \ingroup sacnopts
+/**
+ * @defgroup sacnopts_receiver sACN Receiver Options
+ * @ingroup sacnopts
  *
- * Configuration options for the \ref sacn_receiver module.
+ * Configuration options for the @ref sacn_receiver module.
  * @{
  */
 
-/*!
- * \brief The priority of each sACN receiver thread.
+/**
+ * @brief The priority of each sACN receiver thread.
  *
  * This is usually only meaningful on real-time systems.
  */
@@ -159,8 +159,8 @@
 #define SACN_RECEIVER_THREAD_PRIORITY ETCPAL_THREAD_DEFAULT_PRIORITY
 #endif
 
-/*!
- * \brief The stack size of each sACN receiver thread.
+/**
+ * @brief The stack size of each sACN receiver thread.
  *
  * It's usually only necessary to worry about this on real-time or embedded systems.
  */
@@ -173,8 +173,8 @@
 #undef SACN_RECEIVER_READ_TIMEOUT_MS /* It will get the default value below */
 #endif
 
-/*!
- * \brief The maximum amount of time that a call to sacnrecv_read() will block waiting for data, in
+/**
+ * @brief The maximum amount of time that a call to sacnrecv_read() will block waiting for data, in
  *        milliseconds.
  *
  * It is recommended to keep this time short to avoid delays on shutdown.
@@ -183,8 +183,8 @@
 #define SACN_RECEIVER_READ_TIMEOUT_MS 100
 #endif
 
-/*!
- * \brief The maximum number of sACN universes that can be listened to simultaneously.
+/**
+ * @brief The maximum number of sACN universes that can be listened to simultaneously.
  *
  * Meaningful only if #SACN_DYNAMIC_MEM is defined to 0.
  */
@@ -192,8 +192,8 @@
 #define SACN_RECEIVER_MAX_UNIVERSES 4
 #endif
 
-/*!
- * \brief The maximum number of sources that can be tracked on each universe.
+/**
+ * @brief The maximum number of sources that can be tracked on each universe.
  *
  * Meaningful only if #SACN_DYNAMIC_MEM is defined to 0. This includes sources at any priority; all
  * sources for a given universe are tracked, even those with a lower priority than the
@@ -203,8 +203,8 @@
 #define SACN_RECEIVER_MAX_SOURCES_PER_UNIVERSE 10
 #endif
 
-/*!
- * \brief The total maximum number of sources that can be tracked.
+/**
+ * @brief The total maximum number of sources that can be tracked.
  *
  * Meaningful only if #SACN_DYNAMIC_MEM is defined to 0. Defaults to #SACN_RECEIVER_MAX_UNIVERSES *
  * #SACN_RECEIVER_MAX_SOURCES_PER_UNIVERSE, but can be made lower if an application wants to impose a
@@ -215,8 +215,8 @@
 #define SACN_RECEIVER_TOTAL_MAX_SOURCES (SACN_RECEIVER_MAX_UNIVERSES * SACN_RECEIVER_MAX_SOURCES_PER_UNIVERSE)
 #endif
 
-/*!
- * \brief Whether a new network socket should be created for every sACN universe being listened to.
+/**
+ * @brief Whether a new network socket should be created for every sACN universe being listened to.
  *
  * This option exists to account for quirks in different network stacks. On stacks where multicast
  * traffic is not excessively duplicated between sockets, we conserve sockets by sharing a single
@@ -232,8 +232,8 @@
 #define SACN_RECEIVER_SOCKET_PER_UNIVERSE (!_WIN32 && !__APPLE__)
 #endif
 
-/*!
- * \brief The maximum number of multicast subscriptions supported per shared socket.
+/**
+ * @brief The maximum number of multicast subscriptions supported per shared socket.
  *
  * Only meaningful if #SACN_RECEIVER_SOCKET_PER_UNIVERSE is defined to 0. For the shared socket
  * model, we cap multicast subscriptions at a certain number to keep it below the system limit.
@@ -244,43 +244,43 @@
 #define SACN_RECEIVER_MAX_SUBS_PER_SOCKET 20
 #endif
 
-/*! \cond */
+/** @cond */
 /* TODO investigate. Windows value was 110592 */
 #ifndef SACN_RECEIVER_SOCKET_RCVBUF_SIZE
 #define SACN_RECEIVER_SOCKET_RCVBUF_SIZE 32768
 #endif
-/*! \endcond */
+/** @endcond */
 
-/*!
- * \brief Currently unused; will be used in the future.
+/**
+ * @brief Currently unused; will be used in the future.
  */
 #ifndef SACN_RECEIVER_MAX_THREADS
 #define SACN_RECEIVER_MAX_THREADS 4
 #endif
 
-/*!
+/**
  * @}
  */
 
 /***************************** sACN Send Options *****************************/
 
-/*!
- * \defgroup sacnopts_send sACN Send Options
- * \ingroup sacnopts
+/**
+ * @defgroup sacnopts_send sACN Send Options
+ * @ingroup sacnopts
  *
- * Configuration options for the \ref sacn_source module.
+ * Configuration options for the @ref sacn_source module.
  * @{
  */
 
-/*! \cond */
+/** @cond */
 /* TODO investigate. Windows value was 20 */
 #ifndef SACN_SOURCE_MULTICAST_TTL
 #define SACN_SOURCE_MULTICAST_TTL 64
 #endif
-/*! \endcond */
+/** @endcond */
 
-/*!
- * \brief The maximum number of universes that a source can send to simultaneously.
+/**
+ * @brief The maximum number of universes that a source can send to simultaneously.
  *
  * Meaningful only if #SACN_DYNAMIC_MEM is defined to 0.
  */
@@ -288,22 +288,22 @@
 #define SACN_SOURCE_MAX_UNIVERSES 4
 #endif
 
-/*!
+/**
  * @}
  */
 
 /***************************** sACN DMX Merger Options *****************************/
 
-/*!
- * \defgroup sacn_dmx_merger sACN DMX Merger Options
- * \ingroup sacnopts
+/**
+ * @defgroup sacn_dmx_merger sACN DMX Merger Options
+ * @ingroup sacnopts
  *
- * Configuration options for the \ref sacn_dmx_merger module.
+ * Configuration options for the @ref sacn_dmx_merger module.
  * @{
  */
 
-/*!
- * \brief The maximum number of mergers that can be instanced.
+/**
+ * @brief The maximum number of mergers that can be instanced.
  *
  * Meaningful only if #SACN_DYNAMIC_MEM is defined to 0.
  */
@@ -311,8 +311,8 @@
 #define SACN_DMX_MERGER_MAX_MERGERS SACN_RECEIVER_MAX_UNIVERSES
 #endif
 
-/*!
- * \brief The maximum number of sources that can be merged on each merger instance.
+/**
+ * @brief The maximum number of sources that can be merged on each merger instance.
  *
  * Meaningful only if #SACN_DYNAMIC_MEM is defined to 0.
  */
@@ -320,7 +320,7 @@
 #define SACN_DMX_MERGER_MAX_SOURCES_PER_MERGER SACN_RECEIVER_MAX_SOURCES_PER_UNIVERSE
 #endif
 
-/*!
+/**
  * @}
  */
 

--- a/src/sacn/private/opts.h
+++ b/src/sacn/private/opts.h
@@ -277,29 +277,15 @@
 #ifndef SACN_SOURCE_MULTICAST_TTL
 #define SACN_SOURCE_MULTICAST_TTL 64
 #endif
-
-/* TODO investigate. */
-#ifndef SACN_SOURCE_UNICAST_TTL
-#define SACN_SOURCE_UNICAST_TTL 64
-#endif
 /*! \endcond */
 
 /*!
- * \brief The maximum number of universes that can be sent on simultaneously.
+ * \brief The maximum number of universes that a source can send to simultaneously.
  *
  * Meaningful only if #SACN_DYNAMIC_MEM is defined to 0.
  */
 #ifndef SACN_SOURCE_MAX_UNIVERSES
 #define SACN_SOURCE_MAX_UNIVERSES 4
-#endif
-
-/*!
- * \brief The maximum number of start codes that can be added to each sending universe.
- *
- * Meaningful only if #SACN_DYNAMIC_MEM is defined to 0.
- */
-#ifndef SACN_SOURCE_MAX_STARTCODES_PER_UNIVERSE
-#define SACN_SOURCE_MAX_STARTCODES_PER_UNIVERSE 2
 #endif
 
 /*!

--- a/src/sacn/private/receiver.h
+++ b/src/sacn/private/receiver.h
@@ -17,10 +17,10 @@
  * https://github.com/ETCLabs/sACN
  *****************************************************************************/
 
-/*!
- * \file sacn/private/receiver.h
- * \brief Private constants, types, and function declarations for the
- *        \ref sacn_receiver "sACN Receiver" module.
+/**
+ * @file sacn/private/receiver.h
+ * @brief Private constants, types, and function declarations for the
+ *        @ref sacn_receiver "sACN Receiver" module.
  */
 
 #ifndef SACN_PRIVATE_RECEIVER_H_

--- a/src/sacn/private/source.h
+++ b/src/sacn/private/source.h
@@ -17,9 +17,9 @@
  * https://github.com/ETCLabs/sACN
  *****************************************************************************/
 
-/*!
- * \file sacn/private/source.h
- * \brief Private constants, types, and function declarations for the \ref sacn_source
+/**
+ * @file sacn/private/source.h
+ * @brief Private constants, types, and function declarations for the @ref sacn_source
  *       "sACN Source" module.
  */
 

--- a/src/sacn/private/util.h
+++ b/src/sacn/private/util.h
@@ -17,9 +17,9 @@
  * https://github.com/ETCLabs/sACN
  *****************************************************************************/
 
-/*!
- * \file sacn/private/util.h
- * \brief Utilities used internally by the sACN library
+/**
+ * @file sacn/private/util.h
+ * @brief Utilities used internally by the sACN library
  */
 
 #ifndef SACN_PRIVATE_UTIL_H_

--- a/src/sacn/receiver.c
+++ b/src/sacn/receiver.c
@@ -34,6 +34,7 @@
  - Make sure draft support works properly.  If a source is sending both draft and ratified, the sequence numbers should
    filter out the duplicate packet (just like IPv4 & IPv6).
  - This entire project should build without warnings!!
+ - Make sure the new functionality for receiver/merge_receiver create & reset_networking work with and without good_interfaces, in all combinations (nill, small array, large array, etc).
  - Sync support.  Update TODO comments in receiver & merge_receiver that state sync isn't supported.
 */
 
@@ -237,19 +238,28 @@ void sacn_receiver_config_init(SacnReceiverConfig* config)
  * A sACN receiver can listen on one universe at a time, and each universe can only be listened to
  * by one receiver at at time.
  *
+ * Note that a receiver is considered as successfully created if it is able to successfully use any of the
+ * network interfaces listed in the passed in configuration.  This will only return #kEtcPalErrNoNetints
+ * if none of the interfaces work.
+ *
  * \param[in] config Configuration parameters for the sACN receiver to be created.
  * \param[out] handle Filled in on success with a handle to the sACN receiver.
- * \return #kEtcPalErrOk: Receiver created successful.
+ * \param[in, out] good_interfaces Optional. If non-NULL, good_interfaces is filled in with the list of network
+ * interfaces that were succesfully used.
+ * \return #kEtcPalErrOk: Receiver created successfully.
+ * \return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.
  * \return #kEtcPalErrInvalid: Invalid parameter provided.
  * \return #kEtcPalErrNotInit: Module not initialized.
  * \return #kEtcPalErrExists: A receiver already exists which is listening on the specified universe.
  * \return #kEtcPalErrNoMem: No room to allocate memory for this receiver.
- * \return #kEtcPalErrNoNetints: No network interfaces were found on the system.
  * \return #kEtcPalErrNotFound: A network interface ID given was not found on the system.
  * \return #kEtcPalErrSys: An internal library or system call error occurred.
  */
-etcpal_error_t sacn_receiver_create(const SacnReceiverConfig* config, sacn_receiver_t* handle)
+etcpal_error_t sacn_receiver_create(const SacnReceiverConfig* config, sacn_receiver_t* handle, SacnNetworkChangeResult* good_interfaces)
 {
+  //TODO CHRISTIAN
+  ETCPAL_UNUSED_ARG(good_interfaces);
+
   if (!config || !handle)
     return kEtcPalErrInvalid;
 
@@ -469,22 +479,30 @@ etcpal_error_t sacn_receiver_change_universe(sacn_receiver_t handle, uint16_t ne
  * If this call fails, the caller must call sacn_receiver_destroy for the receiver, because the receiver may be in an
  * invalid state.
  *
+ * Note that the networking reset is considered successful if it is able to successfully use any of the
+ * network interfaces passed in.  This will only return #kEtcPalErrNoNetints if none of the interfaces work.
+ *
  * \param[in] handle Handle to the receiver for which to reset the networking.
  * \param[in] netints Optional array of network interfaces on which to listen to the specified universe. If NULL,
  *  all available network interfaces will be used.
  * \param[in] num_netints Number of elements in the netints array.
+ * \param[in, out] good_interfaces Optional. If non-NULL, good_interfaces is filled in with the list of network
+ * interfaces that were succesfully used.
  * \return #kEtcPalErrOk: Universe changed successfully.
+ * \return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.
  * \return #kEtcPalErrInvalid: Invalid parameter provided.
  * \return #kEtcPalErrNotInit: Module not initialized.
  * \return #kEtcPalErrNotFound: Handle does not correspond to a valid receiver.
  * \return #kEtcPalErrSys: An internal library or system call error occurred.
  */
 etcpal_error_t sacn_receiver_reset_networking(sacn_receiver_t handle, const SacnMcastNetintId* netints,
-                                              size_t num_netints)
+                                              size_t num_netints, SacnNetworkChangeResult* good_interfaces)
 {
+  //TODO CHRISTIAN
   ETCPAL_UNUSED_ARG(handle);
   ETCPAL_UNUSED_ARG(netints);
   ETCPAL_UNUSED_ARG(num_netints);
+  ETCPAL_UNUSED_ARG(good_interfaces);
 
   if (!sacn_initialized())
     return kEtcPalErrNotInit;

--- a/src/sacn/receiver.c
+++ b/src/sacn/receiver.c
@@ -32,7 +32,9 @@
  - Make an example receiver & testing for the c++ header.
  - IPv6 support.  See the CHRISTIAN TODO IPV6 comments for some hints on where to change.
  - Make sure draft support works properly.  If a source is sending both draft and ratified, the sequence numbers should
-   filter out the duplicate packet (just like IPv4 & IPv6).
+   filter out the duplicate packet (just like IPv4 & IPv6).  THIS WILL NOT BE TRUE!!!! because the draft library is now a separate module with different sequencing, etc.
+   So Draft will most likely be treated like a different source...  Should we assume that both won't be sent, or do some checks to ignore draft if we're currently seeing
+   ratified??
  - This entire project should build without warnings!!
  - Make sure the new functionality for receiver/merge_receiver create & reset_networking work with and without good_interfaces, in all combinations (nill, small array, large array, etc).
  - Sync support.  Update TODO comments in receiver & merge_receiver that state sync isn't supported.

--- a/src/sacn/receiver.c
+++ b/src/sacn/receiver.c
@@ -248,9 +248,9 @@ void sacn_receiver_config_init(SacnReceiverConfig* config)
  *
  * @param[in] config Configuration parameters for the sACN receiver to be created.
  * @param[out] handle Filled in on success with a handle to the sACN receiver.
- * @param[in, out] ifaces Optional. If non-NULL, this is the list of interfaces the application wants to use, and the
+ * @param[in, out] netints Optional. If non-NULL, this is the list of interfaces the application wants to use, and the
  * operation_succeeded flags are filled in.  If NULL, all available interfaces are tried.
- * @param[in, out] ifaces_count Optional. The size of ifaces, or 0 if ifaces is NULL.
+ * @param[in, out] num_netints Optional. The size of netints, or 0 if netints is NULL.
  * @return #kEtcPalErrOk: Receiver created successfully.
  * @return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.
  * @return #kEtcPalErrInvalid: Invalid parameter provided.
@@ -261,13 +261,13 @@ void sacn_receiver_config_init(SacnReceiverConfig* config)
  * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
 etcpal_error_t sacn_receiver_create(const SacnReceiverConfig* config, sacn_receiver_t* handle,
-                                    SacnMcastInterfaceToUse* ifaces, size_t ifaces_count)
+                                    SacnMcastInterface* netints, size_t num_netints)
 {
   //TODO CHRISTIAN
   ETCPAL_UNUSED_ARG(config);
   ETCPAL_UNUSED_ARG(handle);
-  ETCPAL_UNUSED_ARG(ifaces);
-  ETCPAL_UNUSED_ARG(ifaces_count);
+  ETCPAL_UNUSED_ARG(netints);
+  ETCPAL_UNUSED_ARG(num_netints);
   return kEtcPalErrNotImpl;
 
 #if 0
@@ -495,9 +495,9 @@ etcpal_error_t sacn_receiver_change_universe(sacn_receiver_t handle, uint16_t ne
  * network interfaces passed in.  This will only return #kEtcPalErrNoNetints if none of the interfaces work.
  *
  * @param[in] handle Handle to the receiver for which to reset the networking.
- * @param[in, out] ifaces Optional. If non-NULL, this is the list of interfaces the application wants to use, and the
+ * @param[in, out] netints Optional. If non-NULL, this is the list of interfaces the application wants to use, and the
  * operation_succeeded flags are filled in.  If NULL, all available interfaces are tried.
- * @param[in, out] ifaces_count Optional. The size of ifaces, or 0 if ifaces is NULL.
+ * @param[in, out] num_netints Optional. The size of netints, or 0 if netints is NULL.
  * @return #kEtcPalErrOk: Universe changed successfully.
  * @return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.
  * @return #kEtcPalErrInvalid: Invalid parameter provided.
@@ -505,13 +505,13 @@ etcpal_error_t sacn_receiver_change_universe(sacn_receiver_t handle, uint16_t ne
  * @return #kEtcPalErrNotFound: Handle does not correspond to a valid receiver.
  * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
-etcpal_error_t sacn_receiver_reset_networking(sacn_receiver_t handle, SacnMcastInterfaceToUse* ifaces,
-                                              size_t ifaces_count)
+etcpal_error_t sacn_receiver_reset_networking(sacn_receiver_t handle, SacnMcastInterface* netints,
+                                              size_t num_netints)
 {
   //TODO CHRISTIAN
   ETCPAL_UNUSED_ARG(handle);
-  ETCPAL_UNUSED_ARG(ifaces);
-  ETCPAL_UNUSED_ARG(ifaces_count);
+  ETCPAL_UNUSED_ARG(netints);
+  ETCPAL_UNUSED_ARG(num_netints);
 
   if (!sacn_initialized())
     return kEtcPalErrNotInit;

--- a/src/sacn/receiver.c
+++ b/src/sacn/receiver.c
@@ -244,7 +244,7 @@ void sacn_receiver_config_init(SacnReceiverConfig* config)
  *
  * \param[in] config Configuration parameters for the sACN receiver to be created.
  * \param[out] handle Filled in on success with a handle to the sACN receiver.
- * \param[in, out] good_interfaces Optional. If non-NULL, good_interfaces is filled in with the list of network
+ * \param[out] good_interfaces Optional. If non-NULL, good_interfaces is filled in with the list of network
  * interfaces that were succesfully used.
  * \return #kEtcPalErrOk: Receiver created successfully.
  * \return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.
@@ -486,7 +486,7 @@ etcpal_error_t sacn_receiver_change_universe(sacn_receiver_t handle, uint16_t ne
  * \param[in] netints Optional array of network interfaces on which to listen to the specified universe. If NULL,
  *  all available network interfaces will be used.
  * \param[in] num_netints Number of elements in the netints array.
- * \param[in, out] good_interfaces Optional. If non-NULL, good_interfaces is filled in with the list of network
+ * \param[out] good_interfaces Optional. If non-NULL, good_interfaces is filled in with the list of network
  * interfaces that were succesfully used.
  * \return #kEtcPalErrOk: Universe changed successfully.
  * \return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.

--- a/src/sacn/receiver.c
+++ b/src/sacn/receiver.c
@@ -224,10 +224,10 @@ void sacn_receiver_deinit(void)
   memset(&receiver_state, 0, sizeof receiver_state);
 }
 
-/*!
- * \brief Initialize an sACN Receiver Config struct to default values.
+/**
+ * @brief Initialize an sACN Receiver Config struct to default values.
  *
- * \param[out] config Config struct to initialize.
+ * @param[out] config Config struct to initialize.
  */
 void sacn_receiver_config_init(SacnReceiverConfig* config)
 {
@@ -237,8 +237,8 @@ void sacn_receiver_config_init(SacnReceiverConfig* config)
   }
 }
 
-/*!
- * \brief Create a new sACN receiver to listen for sACN data on a universe.
+/**
+ * @brief Create a new sACN receiver to listen for sACN data on a universe.
  *
  * A sACN receiver can listen on one universe at a time, and each universe can only be listened to
  * by one receiver at at time.
@@ -246,19 +246,19 @@ void sacn_receiver_config_init(SacnReceiverConfig* config)
  * Note that a receiver is considered as successfully created if it is able to successfully use any of the
  * network interfaces passed in.  This will only return #kEtcPalErrNoNetints if none of the interfaces work.
  *
- * \param[in] config Configuration parameters for the sACN receiver to be created.
- * \param[out] handle Filled in on success with a handle to the sACN receiver.
- * \param[in, out] ifaces Optional. If non-NULL, this is the list of interfaces the application wants to use, and the
+ * @param[in] config Configuration parameters for the sACN receiver to be created.
+ * @param[out] handle Filled in on success with a handle to the sACN receiver.
+ * @param[in, out] ifaces Optional. If non-NULL, this is the list of interfaces the application wants to use, and the
  * operation_succeeded flags are filled in.  If NULL, all available interfaces are tried.
- * \param[in, out] ifaces_count Optional. The size of ifaces, or 0 if ifaces is NULL.
- * \return #kEtcPalErrOk: Receiver created successfully.
- * \return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.
- * \return #kEtcPalErrInvalid: Invalid parameter provided.
- * \return #kEtcPalErrNotInit: Module not initialized.
- * \return #kEtcPalErrExists: A receiver already exists which is listening on the specified universe.
- * \return #kEtcPalErrNoMem: No room to allocate memory for this receiver.
- * \return #kEtcPalErrNotFound: A network interface ID given was not found on the system.
- * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ * @param[in, out] ifaces_count Optional. The size of ifaces, or 0 if ifaces is NULL.
+ * @return #kEtcPalErrOk: Receiver created successfully.
+ * @return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.
+ * @return #kEtcPalErrInvalid: Invalid parameter provided.
+ * @return #kEtcPalErrNotInit: Module not initialized.
+ * @return #kEtcPalErrExists: A receiver already exists which is listening on the specified universe.
+ * @return #kEtcPalErrNoMem: No room to allocate memory for this receiver.
+ * @return #kEtcPalErrNotFound: A network interface ID given was not found on the system.
+ * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
 etcpal_error_t sacn_receiver_create(const SacnReceiverConfig* config, sacn_receiver_t* handle,
                                     SacnMcastInterfaceToUse* ifaces, size_t ifaces_count)
@@ -331,17 +331,17 @@ etcpal_error_t sacn_receiver_create(const SacnReceiverConfig* config, sacn_recei
 #endif
 }
 
-/*!
- * \brief Destroy a sACN receiver instance.
+/**
+ * @brief Destroy a sACN receiver instance.
  *
  * Tears down the receiver and any sources currently being tracked on the receiver's universe.
  * Stops listening for sACN on that universe.
  *
- * \param[in] handle Handle to the receiver to destroy.
- * \return #kEtcPalErrOk: Receiver destroyed successfully.
- * \return #kEtcPalErrNotInit: Module not initialized.
- * \return #kEtcPalErrNotFound: Handle does not correspond to a valid receiver.
- * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ * @param[in] handle Handle to the receiver to destroy.
+ * @return #kEtcPalErrOk: Receiver destroyed successfully.
+ * @return #kEtcPalErrNotInit: Module not initialized.
+ * @return #kEtcPalErrNotFound: Handle does not correspond to a valid receiver.
+ * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
 etcpal_error_t sacn_receiver_destroy(sacn_receiver_t handle)
 {
@@ -372,16 +372,16 @@ etcpal_error_t sacn_receiver_destroy(sacn_receiver_t handle)
   return res;
 }
 
-/*!
- * \brief Get the universe on which a sACN receiver is currently listening.
+/**
+ * @brief Get the universe on which a sACN receiver is currently listening.
  *
- * \param[in] handle Handle to the receiver that we want to query.
- * \param[out] universe_id The retrieved universe.
- * \return #kEtcPalErrOk: Universe retrieved successfully.
- * \return #kEtcPalErrInvalid: Invalid parameter provided.
- * \return #kEtcPalErrNotInit: Module not initialized.
- * \return #kEtcPalErrNotFound: Handle does not correspond to a valid receiver.
- * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ * @param[in] handle Handle to the receiver that we want to query.
+ * @param[out] universe_id The retrieved universe.
+ * @return #kEtcPalErrOk: Universe retrieved successfully.
+ * @return #kEtcPalErrInvalid: Invalid parameter provided.
+ * @return #kEtcPalErrNotInit: Module not initialized.
+ * @return #kEtcPalErrNotFound: Handle does not correspond to a valid receiver.
+ * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
 etcpal_error_t sacn_receiver_get_universe(sacn_receiver_t handle, uint16_t* universe_id)
 {
@@ -394,22 +394,22 @@ etcpal_error_t sacn_receiver_get_universe(sacn_receiver_t handle, uint16_t* univ
   return kEtcPalErrNotImpl;
 }
 
-/*!
- * \brief Change the universe on which an sACN receiver is listening.
+/**
+ * @brief Change the universe on which an sACN receiver is listening.
  *
  * An sACN receiver can only listen on one universe at a time. After this call completes successfully, the receiver is
  * in a sampling period for the new universe and will provide SourcesFound() notifications when appropriate.
  * If this call fails, the caller must call sacn_receiver_destroy for the receiver, because the receiver may be in an
  * invalid state.
  *
- * \param[in] handle Handle to the receiver for which to change the universe.
- * \param[in] new_universe_id New universe number that this receiver should listen to.
- * \return #kEtcPalErrOk: Universe changed successfully.
- * \return #kEtcPalErrInvalid: Invalid parameter provided.
- * \return #kEtcPalErrNotInit: Module not initialized.
- * \return #kEtcPalErrExists: A receiver already exists which is listening on the specified new universe.
- * \return #kEtcPalErrNotFound: Handle does not correspond to a valid receiver.
- * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ * @param[in] handle Handle to the receiver for which to change the universe.
+ * @param[in] new_universe_id New universe number that this receiver should listen to.
+ * @return #kEtcPalErrOk: Universe changed successfully.
+ * @return #kEtcPalErrInvalid: Invalid parameter provided.
+ * @return #kEtcPalErrNotInit: Module not initialized.
+ * @return #kEtcPalErrExists: A receiver already exists which is listening on the specified new universe.
+ * @return #kEtcPalErrNotFound: Handle does not correspond to a valid receiver.
+ * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
 etcpal_error_t sacn_receiver_change_universe(sacn_receiver_t handle, uint16_t new_universe_id)
 {
@@ -481,8 +481,8 @@ etcpal_error_t sacn_receiver_change_universe(sacn_receiver_t handle, uint16_t ne
   return res;
 }
 
-/*!
- * \brief Resets the underlying network sockets and packet receipt state for the sACN receiver..
+/**
+ * @brief Resets the underlying network sockets and packet receipt state for the sACN receiver..
  *
  * This is typically used when the application detects that the list of networking interfaces has changed.
  *
@@ -494,16 +494,16 @@ etcpal_error_t sacn_receiver_change_universe(sacn_receiver_t handle, uint16_t ne
  * Note that the networking reset is considered successful if it is able to successfully use any of the
  * network interfaces passed in.  This will only return #kEtcPalErrNoNetints if none of the interfaces work.
  *
- * \param[in] handle Handle to the receiver for which to reset the networking.
- * \param[in, out] ifaces Optional. If non-NULL, this is the list of interfaces the application wants to use, and the
+ * @param[in] handle Handle to the receiver for which to reset the networking.
+ * @param[in, out] ifaces Optional. If non-NULL, this is the list of interfaces the application wants to use, and the
  * operation_succeeded flags are filled in.  If NULL, all available interfaces are tried.
- * \param[in, out] ifaces_count Optional. The size of ifaces, or 0 if ifaces is NULL.
- * \return #kEtcPalErrOk: Universe changed successfully.
- * \return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.
- * \return #kEtcPalErrInvalid: Invalid parameter provided.
- * \return #kEtcPalErrNotInit: Module not initialized.
- * \return #kEtcPalErrNotFound: Handle does not correspond to a valid receiver.
- * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ * @param[in, out] ifaces_count Optional. The size of ifaces, or 0 if ifaces is NULL.
+ * @return #kEtcPalErrOk: Universe changed successfully.
+ * @return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.
+ * @return #kEtcPalErrInvalid: Invalid parameter provided.
+ * @return #kEtcPalErrNotInit: Module not initialized.
+ * @return #kEtcPalErrNotFound: Handle does not correspond to a valid receiver.
+ * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
 etcpal_error_t sacn_receiver_reset_networking(sacn_receiver_t handle, SacnMcastInterfaceToUse* ifaces,
                                               size_t ifaces_count)
@@ -519,12 +519,12 @@ etcpal_error_t sacn_receiver_reset_networking(sacn_receiver_t handle, SacnMcastI
   return kEtcPalErrNotImpl;
 }
 
-/*!
- * \brief Set the current version of the sACN standard to which the module is listening.
+/**
+ * @brief Set the current version of the sACN standard to which the module is listening.
  *
  * This is a global option across all listening receivers.
  *
- * \param[in] version Version of sACN to listen to.
+ * @param[in] version Version of sACN to listen to.
  */
 void sacn_receiver_set_standard_version(sacn_standard_version_t version)
 {
@@ -538,12 +538,12 @@ void sacn_receiver_set_standard_version(sacn_standard_version_t version)
   }
 }
 
-/*!
- * \brief Get the current version of the sACN standard to which the module is listening.
+/**
+ * @brief Get the current version of the sACN standard to which the module is listening.
  *
  * This is a global option across all listening receivers.
  *
- * \return Version of sACN to which the module is listening, or #kSacnStandardVersionNone if the module is
+ * @return Version of sACN to which the module is listening, or #kSacnStandardVersionNone if the module is
  *         not initialized.
  */
 sacn_standard_version_t sacn_receiver_get_standard_version()
@@ -561,14 +561,14 @@ sacn_standard_version_t sacn_receiver_get_standard_version()
   return res;
 }
 
-/*!
- * \brief Set the expired notification wait time.
+/**
+ * @brief Set the expired notification wait time.
  *
  * The library will wait at least this long after a data loss condition has been encountered before
- * sending a \ref SacnSourcesLostCallback "sources_lost()" notification. However, the wait may be
- * longer due to the data loss algorithm (see \ref data_loss_behavior).
+ * sending a @ref SacnSourcesLostCallback "sources_lost()" notification. However, the wait may be
+ * longer due to the data loss algorithm (see @ref data_loss_behavior).
  *
- * \param[in] wait_ms Wait time in milliseconds.
+ * @param[in] wait_ms Wait time in milliseconds.
  */
 void sacn_receiver_set_expired_wait(uint32_t wait_ms)
 {
@@ -582,14 +582,14 @@ void sacn_receiver_set_expired_wait(uint32_t wait_ms)
   }
 }
 
-/*!
- * \brief Get the current value of the expired notification wait time.
+/**
+ * @brief Get the current value of the expired notification wait time.
  *
  * The library will wait at least this long after a data loss condition has been encountered before
- * sending a \ref SacnSourcesLostCallback "sources_lost()" notification. However, the wait may be
- * longer due to the data loss algorithm (see \ref data_loss_behavior).
+ * sending a @ref SacnSourcesLostCallback "sources_lost()" notification. However, the wait may be
+ * longer due to the data loss algorithm (see @ref data_loss_behavior).
  *
- * \return Wait time in milliseconds.
+ * @return Wait time in milliseconds.
  */
 uint32_t sacn_receiver_get_expired_wait()
 {
@@ -1356,7 +1356,7 @@ void process_receivers(SacnRecvThreadContext* recv_thread_context)
     // sampling_ended = get_sampling_ended_buffer(recv_thread_context->thread_id, num_receivers);
     sources_lost = get_sources_lost_buffer(recv_thread_context->thread_id, num_receivers);
     sources_found = get_sources_found_buffer(recv_thread_context->thread_id, num_receivers);
-    if (/*!sampling_ended ||*/ !sources_lost || !sources_found)
+    if (/* !sampling_ended || */ !sources_lost || !sources_found)
     {
       sacn_unlock();
       SACN_LOG_ERR("Could not allocate memory to track state data for sACN receivers!");

--- a/src/sacn/source.c
+++ b/src/sacn/source.c
@@ -161,7 +161,7 @@ etcpal_error_t sacn_source_change_name(sacn_source_t handle, const char* new_nam
  * @brief Destroy an sACN source instance.
  *
  * Stops sending all universes for this source. The destruction is queued, and actually occurs
- * on a call to sacn_source_process_sources() after an additional three packets have been sent with the
+ * on a call to sacn_source_process_all() after an additional three packets have been sent with the
  * "Stream_Terminated" option set. The source will also stop transmitting sACN universe discovery packets.
  *
  * Even though the destruction is queued, after this call the library will no longer use the priorities_buffer
@@ -208,7 +208,7 @@ etcpal_error_t sacn_source_add_universe(sacn_source_t handle, const SacnSourceUn
  * @brief Remove a universe from a source.
  *
  * This queues the source for removal. The destruction actually occurs
- * on a call to sacn_source_process_sources() after an additional three packets have been sent with the
+ * on a call to sacn_source_process_all() after an additional three packets have been sent with the
  * "Stream_Terminated" option set.
  *
  * The source will also stop transmitting sACN universe discovery packets for that universe.
@@ -256,7 +256,7 @@ etcpal_error_t sacn_source_add_unicast_destination(sacn_source_t handle, uint16_
  * @brief Remove a unicast destination on a source's universe.
  *
  * This queues the address for removal. The removal actually occurs
- * on a call to sacn_source_process_sources() after an additional three packets have been sent with the
+ * on a call to sacn_source_process_all() after an additional three packets have been sent with the
  * "Stream_Terminated" option set.
  *
  * @param[in] handle Handle to the source to change.
@@ -297,15 +297,15 @@ etcpal_error_t sacn_source_change_priority(sacn_source_t handle, uint16_t univer
 }
 
 /**
- * @brief Change the sending_preview option on a universe of a sACN source.
+ * @brief Change the send_preview option on a universe of a sACN source.
  *
  * Sets the state of a flag in the outgoing sACN packets that indicates that the data is (from
  * E1.31) "intended for use in visualization or media server preview applications and shall not be
  * used to generate live output."
  *
  * @param[in] handle Handle to the source for which to set the Preview_Data option.
- * @param[in] new_preview_flag The new sending_preview option.
- * @return #kEtcPalErrOk: sending_preview option set successfully.
+ * @param[in] new_preview_flag The new send_preview option.
+ * @return #kEtcPalErrOk: send_preview option set successfully.
  * @return #kEtcPalErrInvalid: Invalid parameter provided.
  * @return #kEtcPalErrNotInit: Module not initialized.
  * @return #kEtcPalErrNotFound: Handle does not correspond to a valid source or the universe is not on that source.
@@ -354,7 +354,7 @@ etcpal_error_t sacn_source_change_synchronization_universe(sacn_source_t handle,
  *
  * Immediately sends a sACN packet with the provided start code and data.
  * This function is intended for sACN packets that have a startcode other than 0 or 0xdd, since those
- * start codes are taken care of by sacn_source_process_sources().
+ * start codes are taken care of by sacn_source_process_all().
  *
  * @param[in] handle Handle to the source.
  * @param[in] universe Universe to send on.
@@ -409,7 +409,7 @@ etcpal_error_t sacn_source_send_synchronization(sacn_source_t handle, uint16_t u
 
 /**
  * @brief Indicate that the data in the buffer for this source and universe has changed and
- *        should be sent on the next call to sacn_source_process_sources().
+ *        should be sent on the next call to sacn_source_process_all().
  *
  * @param[in] handle Handle to the source to mark as dirty.
  * @param[in] universe Universe to mark as dirty.
@@ -424,7 +424,7 @@ void sacn_source_set_dirty(sacn_source_t handle, uint16_t universe)
 
 /**
  * @brief Indicate that the data in the buffers for a list of universes on a source  has
- *        changed and should be sent on the next call to sacn_source_process_sources().
+ *        changed and should be sent on the next call to sacn_source_process_all().
  *
  * @param[in] handle Handle to the source.
  * @param[in] universes Array of universes to mark as dirty. Must not be NULL.
@@ -443,7 +443,7 @@ void sacn_source_set_list_dirty(sacn_source_t handle, const uint16_t* universes,
  * @brief Like sacn_source_set_dirty, but also sets the force_sync flag on the packet.
  *
  * This function indicates that the data in the buffer for this source and universe has changed,
- * and should be sent on the next call to sacn_source_process_sources().  Additionally, the packet
+ * and should be sent on the next call to sacn_source_process_all().  Additionally, the packet
  * to be sent will have its force_synchronization option flag set.
  *
  * If no synchronization universe is configured, this function acts like a direct call to sacn_source_set_dirty().
@@ -476,7 +476,7 @@ void sacn_source_set_dirty_and_force_sync(sacn_source_t handle, uint16_t univers
  *         track when destroyed sources have finished sending the terminated packets and actually
  *         been destroyed.
  */
-size_t sacn_source_process_sources(void)
+size_t sacn_source_process_all(void)
 {
   // TODO CHRISTIAN
   return 0;

--- a/src/sacn/source.c
+++ b/src/sacn/source.c
@@ -19,7 +19,9 @@
 
 /*********** CHRISTIAN's BIG OL' TODO LIST: *************************************
  - Make sure I didn't miss any requirements or details from the protocol.
- - A whole lotta implementation.  You should be able to base some this on the earlier C++ library.
+ - A whole lotta implementation.  You should be able to base some this on the earlier C++ library, but also look at the
+ spec for 0xdd, since the old library didn't handle intermixing 0x00 & 0xdd on take-control and release-control.  Ray
+ can help there, too.
  - Get usage/API documentation in place and cleaned up so we can have a larger review.
  - Make sure everything works with static & dynamic memory.
  - This entire project should build without warnings!!
@@ -28,9 +30,9 @@
  - IPv6 support.
  - Sync support.  Update TODO comments in source.h & .c that state sync isn't supported.
  --------------NICK CLEAN UP
- - ***** HANS reset networking & network creation errors!  Also change in reciever APIs!
  - DRAFT SUPPORT can this just be a flag (send draft in addition to ratified?) Check requirements!!
  - C++ headers & initial test framework
+ - The C++ headers should return the working interfaces on Create and Reset!!!!
  - Any TODOS for me
 */
 
@@ -106,22 +108,31 @@ void sacn_source_universe_config_init(SacnSourceUniverseConfig* config, uint16_t
  *
  * This creates the instance of the source, but no data is sent until sacn_source_add_universe() is called.
  *
+ * Note that a source is considered as successfully created if it is able to successfully use any of the
+ * network interfaces listed in the passed in configuration.  This will only return #kEtcPalErrNoNetints
+ * if none of the interfaces work.
+ *
  * \param[in] config Configuration parameters for the sACN source to be created.
  * \param[out] handle Filled in on success with a handle to the sACN source.
+ * \param[in, out] good_interfaces Optional. If non-NULL, good_interfaces is filled in with the list of network
+ * interfaces that were succesfully used.
  * \return #kEtcPalErrOk: Source successfully created.
+ * \return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.
  * \return #kEtcPalErrInvalid: Invalid parameter provided.
  * \return #kEtcPalErrNotInit: Module not initialized.
- * \return #kEtcPalErrNoMem: No room to allocate additional source.
+ * \return #kEtcPalErrNoMem: No room to allocate an additional source.
  * \return #kEtcPalErrNotFound: A network interface ID given was not found on the system.
  * \return #kEtcPalErrSys: An internal library or system call error occurred.
  */
-etcpal_error_t sacn_source_create(const SacnSourceConfig* config, sacn_source_t* handle)
+etcpal_error_t sacn_source_create(const SacnSourceConfig* config, sacn_source_t* handle,
+                                  SacnNetworkChangeResult* good_interfaces)
 {
   // TODO CHRISTIAN
   // If the Tick thread hasn't been started yet, start it if the config isn't manual.
 
   ETCPAL_UNUSED_ARG(config);
   ETCPAL_UNUSED_ARG(handle);
+  ETCPAL_UNUSED_ARG(good_interfaces);
   return kEtcPalErrNotImpl;
 }
 
@@ -487,22 +498,30 @@ size_t sacn_source_process_sources(void)
  * If this call fails, the caller must call sacn_source_destroy(), because the source may be in an
  * invalid state.
  *
+ * Note that the networking reset is considered successful if it is able to successfully use any of the
+ * network interfaces passed in.  This will only return #kEtcPalErrNoNetints if none of the interfaces work.
+ *
  * \param[in] handle Handle to the source for which to reset the networking.
  * \param[in] netints Optional array of network interfaces on which to listen to the specified universe. If NULL,
  *  all available network interfaces will be used.
  * \param[in] num_netints Number of elements in the netints array.
+ * \param[in, out] good_interfaces Optional. If non-NULL, good_interfaces is filled in with the list of network
+ * interfaces that were succesfully used.
  * \return #kEtcPalErrOk: Source changed successfully.
+ * \return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.
  * \return #kEtcPalErrInvalid: Invalid parameter provided.
  * \return #kEtcPalErrNotInit: Module not initialized.
  * \return #kEtcPalErrNotFound: Handle does not correspond to a valid receiver.
  * \return #kEtcPalErrSys: An internal library or system call error occurred.
  */
-etcpal_error_t sacn_source_reset_networking(sacn_source_t handle, const SacnMcastNetintId* netints, size_t num_netints)
+etcpal_error_t sacn_source_reset_networking(sacn_source_t handle, const SacnMcastNetintId* netints, size_t num_netints,
+                                            SacnNetworkChangeResult* good_interfaces)
 {
   // TODO CHRISTIAN
   ETCPAL_UNUSED_ARG(handle);
   ETCPAL_UNUSED_ARG(netints);
   ETCPAL_UNUSED_ARG(num_netints);
+  ETCPAL_UNUSED_ARG(good_interfaces);
 
   return kEtcPalErrNotImpl;
 }

--- a/src/sacn/source.c
+++ b/src/sacn/source.c
@@ -110,9 +110,9 @@ void sacn_source_universe_config_init(SacnSourceUniverseConfig* config, uint16_t
  *
  * @param[in] config Configuration parameters for the sACN source to be created.
  * @param[out] handle Filled in on success with a handle to the sACN source.
- * @param[in, out] ifaces Optional. If non-NULL, this is the list of interfaces the application wants to use, and the
- * operation_succeeded flags are filled in.  If NULL, all available interfaces are tried.
- * @param[in, out] ifaces_count Optional. The size of ifaces, or 0 if ifaces is NULL.
+ * @param[in, out] num_netints Optional. If non-NULL, this is the list of interfaces the application wants to use, and
+ * the operation_succeeded flags are filled in.  If NULL, all available interfaces are tried.
+ * @param[in, out] num_netints Optional. The size of netints, or 0 if netints is NULL.
  * @return #kEtcPalErrOk: Source successfully created.
  * @return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.
  * @return #kEtcPalErrInvalid: Invalid parameter provided.
@@ -122,15 +122,15 @@ void sacn_source_universe_config_init(SacnSourceUniverseConfig* config, uint16_t
  * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
 etcpal_error_t sacn_source_create(const SacnSourceConfig* config, sacn_source_t* handle,
-                                  SacnMcastInterfaceToUse* ifaces, size_t ifaces_count)
+                                  SacnMcastInterface* netints, size_t num_netints)
 {
   // TODO CHRISTIAN
   // If the Tick thread hasn't been started yet, start it if the config isn't manual.
 
   ETCPAL_UNUSED_ARG(config);
   ETCPAL_UNUSED_ARG(handle);
-  ETCPAL_UNUSED_ARG(ifaces);
-  ETCPAL_UNUSED_ARG(ifaces_count);
+  ETCPAL_UNUSED_ARG(netints);
+  ETCPAL_UNUSED_ARG(num_netints);
   return kEtcPalErrNotImpl;
 }
 
@@ -497,9 +497,9 @@ size_t sacn_source_process_sources(void)
  * network interfaces passed in.  This will only return #kEtcPalErrNoNetints if none of the interfaces work.
  *
  * @param[in] handle Handle to the source for which to reset the networking.
- * @param[in, out] ifaces Optional. If non-NULL, this is the list of interfaces the application wants to use, and the
+ * @param[in, out] netints Optional. If non-NULL, this is the list of interfaces the application wants to use, and the
  * operation_succeeded flags are filled in.  If NULL, all available interfaces are tried.
- * @param[in, out] ifaces_count Optional. The size of ifaces, or 0 if ifaces is NULL.
+ * @param[in, out] num_netints Optional. The size of netints, or 0 if netints is NULL.
  * @return #kEtcPalErrOk: Source changed successfully.
  * @return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.
  * @return #kEtcPalErrInvalid: Invalid parameter provided.
@@ -507,12 +507,12 @@ size_t sacn_source_process_sources(void)
  * @return #kEtcPalErrNotFound: Handle does not correspond to a valid source.
  * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
-etcpal_error_t sacn_source_reset_networking(sacn_source_t handle, SacnMcastInterfaceToUse* ifaces, size_t ifaces_count)
+etcpal_error_t sacn_source_reset_networking(sacn_source_t handle, SacnMcastInterface* netints, size_t num_netints)
 {
   // TODO CHRISTIAN
   ETCPAL_UNUSED_ARG(handle);
-  ETCPAL_UNUSED_ARG(ifaces);
-  ETCPAL_UNUSED_ARG(ifaces_count);
+  ETCPAL_UNUSED_ARG(netints);
+  ETCPAL_UNUSED_ARG(num_netints);
 
   return kEtcPalErrNotImpl;
 }

--- a/src/sacn/source.c
+++ b/src/sacn/source.c
@@ -26,11 +26,9 @@
  - Make an example source that uses the new api.
  - Make an example source & testing for the c++ header.
  - IPv6 support.
+ - Sync support.  Update TODO comments in source.h & .c that state sync isn't supported.
  --------------NICK CLEAN UP
- - Make sure draft support works properly.  If a source is sending both draft and ratified, the sequence numbers should
-   filter out the duplicate packet (just like IPv4 & IPv6).
- - Sync support.  Update TODO comments in receiver & merge_receiver that state sync isn't supported.
- - HANS reset networking & network creation errors?
+ - HANS reset networking & network creation errors!  Also change in reciever APIs!
  - DRAFT SUPPORT can this just be a flag (send draft in addition to ratified?) Check requirements!!
  - C++ headers & initial test framework
  - Any TODOS for me
@@ -175,7 +173,7 @@ void sacn_source_destroy(sacn_source_t handle)
  * Adds a universe to a source. If dirty_now is true, the source will start sending values on the
  * next call to sacn_source_process_sources(). If dirty_now is false, the applicaton must call sacn_source_set_dirty()
  * to mark it ready for processing.
- * 
+ *
  * If the source is not marked as unicast_only, the source will add the universe to its sACN Universe
  * Discovery packets.
 
@@ -236,7 +234,8 @@ void sacn_source_remove_universe(sacn_source_t handle, uint16_t universe)
  * \return #kEtcPalErrNotFound: Handle does not correspond to a valid source or the universe is not on that source.
  * \return #kEtcPalErrSys: An internal library or system call error occurred.
  */
-etcpal_error_t sacn_source_add_unicast_destination(sacn_source_t handle, uint16_t universe, const EtcPalIpAddr* dest, bool dirty_now)
+etcpal_error_t sacn_source_add_unicast_destination(sacn_source_t handle, uint16_t universe, const EtcPalIpAddr* dest,
+                                                   bool dirty_now)
 {
   // TODO CHRISTIAN
 
@@ -256,7 +255,8 @@ etcpal_error_t sacn_source_add_unicast_destination(sacn_source_t handle, uint16_
  *
  * \param[in] handle Handle to the source to change.
  * \param[in] universe Universe to change.
- * \param[in] dest The destination IP.  May not be NULL, and must match the address passed to sacn_source_add_unicast_destination().
+ * \param[in] dest The destination IP.  May not be NULL, and must match the address passed to
+ * sacn_source_add_unicast_destination().
  */
 void sacn_source_remove_unicast_destination(sacn_source_t handle, uint16_t universe, const EtcPalIpAddr* dest)
 {
@@ -282,10 +282,11 @@ void sacn_source_remove_unicast_destination(sacn_source_t handle, uint16_t unive
  */
 etcpal_error_t sacn_source_change_priority(sacn_source_t handle, uint16_t universe, uint8_t new_priority)
 {
+  // TODO CHRISTIAN
+
   ETCPAL_UNUSED_ARG(handle);
   ETCPAL_UNUSED_ARG(universe);
   ETCPAL_UNUSED_ARG(new_priority);
-  // TODO
   return kEtcPalErrNotImpl;
 }
 
@@ -306,10 +307,39 @@ etcpal_error_t sacn_source_change_priority(sacn_source_t handle, uint16_t univer
  */
 etcpal_error_t sacn_source_change_preview_flag(sacn_source_t handle, uint16_t universe, bool new_preview_flag)
 {
+  // TODO CHRISTIAN
+
   ETCPAL_UNUSED_ARG(handle);
   ETCPAL_UNUSED_ARG(universe);
   ETCPAL_UNUSED_ARG(new_preview_flag);
+  return kEtcPalErrNotImpl;
+}
+
+/*!
+ * \brief Changes the synchronize uinverse for a universe of a sACN source.
+ *
+ * This will change the synchronization universe used by a sACN universe on the source.
+ * If this value is 0, synchronization is turned off for that universe.
+ *
+ * TODO: At this time, synchronization is not supported by this library.
+ *
+ * \param[in] handle Handle to the source to change.
+ * \param[in] universe The universe to change.
+ * \param[in] new_sync_universe The new synchronization universe to set.
+ * \return #kEtcPalErrOk: sync_universe set successfully.
+ * \return #kEtcPalErrInvalid: Invalid parameter provided.
+ * \return #kEtcPalErrNotInit: Module not initialized.
+ * \return #kEtcPalErrNotFound: Handle does not correspond to a valid source or the universe is not on that source.
+ * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ */
+etcpal_error_t sacn_source_change_synchronization_universe(sacn_source_t handle, uint16_t universe,
+                                                           uint16_t new_sync_universe)
+{
   // TODO
+
+  ETCPAL_UNUSED_ARG(handle);
+  ETCPAL_UNUSED_ARG(universe);
+  ETCPAL_UNUSED_ARG(new_sync_universe);
   return kEtcPalErrNotImpl;
 }
 
@@ -346,6 +376,32 @@ etcpal_error_t sacn_source_send_now(sacn_source_t handle, uint16_t universe, uin
 }
 
 /*!
+ * \brief Immediately sends a synchronization packet for the universe on a source.
+ *
+ * This will cause an immediate transmission of a synchronization packet for the source/universe.
+ * If the universe does not have a synchronization universe configured, this call is ignored.
+ *
+ * TODO: At this time, synchronization is not supported by this library.
+ *
+ * \param[in] handle Handle to the source.
+ * \param[in] universe Universe to send on.
+ * \return #kEtcPalErrOk: Message successfully sent.
+ * \return #kEtcPalErrInvalid: Invalid parameter provided.
+ * \return #kEtcPalErrNotInit: Module not initialized.
+ * \return #kEtcPalErrNotFound: Handle does not correspond to a valid source, or the universe was not found on this
+ *                              source.
+ * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ */
+etcpal_error_t sacn_source_send_synchronization(sacn_source_t handle, uint16_t universe)
+{
+  // TODO
+
+  ETCPAL_UNUSED_ARG(handle);
+  ETCPAL_UNUSED_ARG(universe);
+  return kEtcPalErrNotImpl;
+}
+
+/*!
  * \brief Indicate that the data in the buffer for this source and universe has changed and
  *        should be sent on the next call to sacn_source_process_sources().
  *
@@ -354,7 +410,7 @@ etcpal_error_t sacn_source_send_now(sacn_source_t handle, uint16_t universe, uin
  */
 void sacn_source_set_dirty(sacn_source_t handle, uint8_t universe)
 {
-  //TODO CHRISTIAN
+  // TODO CHRISTIAN
 
   ETCPAL_UNUSED_ARG(handle);
   ETCPAL_UNUSED_ARG(universe);
@@ -375,6 +431,28 @@ void sacn_source_set_list_dirty(sacn_source_t handle, uint8_t* universes, size_t
   ETCPAL_UNUSED_ARG(handle);
   ETCPAL_UNUSED_ARG(universes);
   ETCPAL_UNUSED_ARG(num_universes);
+}
+
+/*!
+ * \brief Like sacn_source_set_dirty, but also sets the force_sync flag on the packet.
+ *
+ * This function indicates that the data in the buffer for this source and universe has changed,
+ * and should be sent on the next call to sacn_source_process_sources().  Additionally, the packet
+ * to be sent will have its force_synchronization option flag set.
+ *
+ * If no synchronization universe is configured, this function acts like a direct call to sacn_source_set_dirty().
+ *
+ * TODO: At this time, synchronization is not supported by this library.
+ *
+ * \param[in] handle Handle to the source to mark as dirty.
+ * \param[in] universe Universe to mark as dirty.
+ */
+void sacn_source_set_dirty_and_force_sync(sacn_source_t handle, uint8_t universe)
+{
+  // TODO
+
+  ETCPAL_UNUSED_ARG(handle);
+  ETCPAL_UNUSED_ARG(universe);
 }
 
 /*!
@@ -419,10 +497,9 @@ size_t sacn_source_process_sources(void)
  * \return #kEtcPalErrNotFound: Handle does not correspond to a valid receiver.
  * \return #kEtcPalErrSys: An internal library or system call error occurred.
  */
-etcpal_error_t sacn_source_reset_networking(sacn_source_t handle, const SacnMcastNetintId* netints,
-                                              size_t num_netints)
+etcpal_error_t sacn_source_reset_networking(sacn_source_t handle, const SacnMcastNetintId* netints, size_t num_netints)
 {
-  //TODO CHRISTIAN
+  // TODO CHRISTIAN
   ETCPAL_UNUSED_ARG(handle);
   ETCPAL_UNUSED_ARG(netints);
   ETCPAL_UNUSED_ARG(num_netints);

--- a/src/sacn/source.c
+++ b/src/sacn/source.c
@@ -27,13 +27,9 @@
  - This entire project should build without warnings!!
  - Make an example source that uses the new api.
  - Make an example source & testing for the c++ header.
+ - Don't forget the Draft library!!!
  - IPv6 support.
  - Sync support.  Update TODO comments in source.h & .c that state sync isn't supported.
- --------------NICK CLEAN UP
- - RE-EXAMINE!!!!! -- The C++ headers should return the working interfaces on Create and Reset!!!!
- - Flesh out Draft API, and make C++ interface that can encompass both draft & ratified!!!
- - DRAFT SUPPORT can this just be a flag (send draft in addition to ratified?) Check requirements!!
- - Any TODOS for me
 */
 
 #include "sacn/source.h"

--- a/src/sacn/source.c
+++ b/src/sacn/source.c
@@ -484,11 +484,11 @@ size_t sacn_source_process_sources(void)
 }
 
 /*!
- * \brief Resets the underlying network sockets for the sACN source..
+ * \brief Resets the underlying network sockets for the sACN source.
  *
  * This is typically used when the application detects that the list of networking interfaces has changed.
  *
- * After this call completes successfully, the all universes on a source are considered new & dirty by the
+ * After this call completes successfully, all universes on a source are considered new & dirty by the
  * per-address priority logic in sacn_source_process_sources.
  *
  * If this call fails, the caller must call sacn_source_destroy(), because the source may be in an

--- a/src/sacn/source.c
+++ b/src/sacn/source.c
@@ -30,9 +30,10 @@
  - IPv6 support.
  - Sync support.  Update TODO comments in source.h & .c that state sync isn't supported.
  --------------NICK CLEAN UP
- - DRAFT SUPPORT can this just be a flag (send draft in addition to ratified?) Check requirements!!
  - C++ headers & initial test framework
- - The C++ headers should return the working interfaces on Create and Reset!!!!
+ - RE-EXAMINE!!!!! -- The C++ headers should return the working interfaces on Create and Reset!!!!
+ - Flesh out Draft API, and make C++ interface that can encompass both draft & ratified!!!
+ - DRAFT SUPPORT can this just be a flag (send draft in addition to ratified?) Check requirements!!
  - Any TODOS for me
 */
 

--- a/src/sacn/source.c
+++ b/src/sacn/source.c
@@ -28,7 +28,7 @@
  - IPv6 support.
  - Sync support.  Update TODO comments in source.h & .c that state sync isn't supported.
  --------------NICK CLEAN UP
- - HANS reset networking & network creation errors!  Also change in reciever APIs!
+ - ***** HANS reset networking & network creation errors!  Also change in reciever APIs!
  - DRAFT SUPPORT can this just be a flag (send draft in addition to ratified?) Check requirements!!
  - C++ headers & initial test framework
  - Any TODOS for me
@@ -458,7 +458,7 @@ void sacn_source_set_dirty_and_force_sync(sacn_source_t handle, uint8_t universe
 /*!
  * \brief Process created sources and do the actual sending of sACN data on all universes.
  *
- * Note: Unless you created the source with manual_process set to true, this will be automatically
+ * Note: Unless you created the source with manually_process_source set to true, this will be automatically
  * called by an internal thread of the module. Otherwise, this must be called at the maximum rate
  * at which the application will send sACN.
  *

--- a/src/sacn/source.c
+++ b/src/sacn/source.c
@@ -110,7 +110,7 @@ void sacn_source_universe_config_init(SacnSourceUniverseConfig* config, uint16_t
  *
  * @param[in] config Configuration parameters for the sACN source to be created.
  * @param[out] handle Filled in on success with a handle to the sACN source.
- * @param[in, out] num_netints Optional. If non-NULL, this is the list of interfaces the application wants to use, and
+ * @param[in, out] netints Optional. If non-NULL, this is the list of interfaces the application wants to use, and
  * the operation_succeeded flags are filled in.  If NULL, all available interfaces are tried.
  * @param[in, out] num_netints Optional. The size of netints, or 0 if netints is NULL.
  * @return #kEtcPalErrOk: Source successfully created.

--- a/src/sacn/source.c
+++ b/src/sacn/source.c
@@ -476,7 +476,7 @@ void sacn_source_set_dirty_and_force_sync(sacn_source_t handle, uint16_t univers
  *         track when destroyed sources have finished sending the terminated packets and actually
  *         been destroyed.
  */
-size_t sacn_source_process_all(void)
+int sacn_source_process_all(void)
 {
   // TODO CHRISTIAN
   return 0;

--- a/src/sacn/source.c
+++ b/src/sacn/source.c
@@ -283,7 +283,7 @@ void sacn_source_remove_unicast_destination(sacn_source_t handle, uint16_t unive
  * \brief Change the priority of a universe on a sACN source.
  *
  * \param[in] handle Handle to the source for which to set the priority.
- * \param[in] universe Unviverse to change.
+ * \param[in] universe Universe to change.
  * \param[in] new_priority New priority of the data sent from this source. Valid range is 0 to 200,
  *                         inclusive.
  * \return #kEtcPalErrOk: Priority set successfully.
@@ -420,7 +420,7 @@ etcpal_error_t sacn_source_send_synchronization(sacn_source_t handle, uint16_t u
  * \param[in] handle Handle to the source to mark as dirty.
  * \param[in] universe Universe to mark as dirty.
  */
-void sacn_source_set_dirty(sacn_source_t handle, uint8_t universe)
+void sacn_source_set_dirty(sacn_source_t handle, uint16_t universe)
 {
   // TODO CHRISTIAN
 
@@ -436,7 +436,7 @@ void sacn_source_set_dirty(sacn_source_t handle, uint8_t universe)
  * \param[in] universes Array of universes to mark as dirty. Must not be NULL.
  * \param[in] num_universes Size of the universes array.
  */
-void sacn_source_set_list_dirty(sacn_source_t handle, uint8_t* universes, size_t num_universes)
+void sacn_source_set_list_dirty(sacn_source_t handle, const uint16_t* universes, size_t num_universes)
 {
   // TODO CHRISTIAN
 
@@ -459,7 +459,7 @@ void sacn_source_set_list_dirty(sacn_source_t handle, uint8_t* universes, size_t
  * \param[in] handle Handle to the source to mark as dirty.
  * \param[in] universe Universe to mark as dirty.
  */
-void sacn_source_set_dirty_and_force_sync(sacn_source_t handle, uint8_t universe)
+void sacn_source_set_dirty_and_force_sync(sacn_source_t handle, uint16_t universe)
 {
   // TODO
 
@@ -503,7 +503,7 @@ size_t sacn_source_process_sources(void)
  * network interfaces passed in.  This will only return #kEtcPalErrNoNetints if none of the interfaces work.
  *
  * \param[in] handle Handle to the source for which to reset the networking.
- * \param[in] netints Optional array of network interfaces on which to listen to the specified universe. If NULL,
+ * \param[in] netints Optional array of network interfaces on which to send to the specified universe. If NULL,
  *  all available network interfaces will be used.
  * \param[in] num_netints Number of elements in the netints array.
  * \param[in, out] good_interfaces Optional. If non-NULL, good_interfaces is filled in with the list of network

--- a/src/sacn/source.c
+++ b/src/sacn/source.c
@@ -102,16 +102,17 @@ void sacn_source_universe_config_init(SacnSourceUniverseConfig* config, uint16_t
 /*!
  * \brief Create a new sACN source to send sACN data.
  *
- * This creates the instance of the source, but no data is sent until sacn_source_add_universe() is called.
+ * This creates the instance of the source, but no data is sent until sacn_source_add_universe() and
+ * sacn_source_set_dirty() is called.
  *
  * Note that a source is considered as successfully created if it is able to successfully use any of the
- * network interfaces listed in the passed in configuration.  This will only return #kEtcPalErrNoNetints
- * if none of the interfaces work.
+ * network interfaces passed in.  This will only return #kEtcPalErrNoNetints if none of the interfaces work.
  *
  * \param[in] config Configuration parameters for the sACN source to be created.
  * \param[out] handle Filled in on success with a handle to the sACN source.
- * \param[out] good_interfaces Optional. If non-NULL, good_interfaces is filled in with the list of network
- * interfaces that were succesfully used.
+ * \param[in, out] ifaces Optional. If non-NULL, this is the list of interfaces the application wants to use, and the
+ * operation_succeeded flags are filled in.  If NULL, all available interfaces are tried.
+ * \param[in, out] ifaces_count Optional. The size of ifaces, or 0 if ifaces is NULL.
  * \return #kEtcPalErrOk: Source successfully created.
  * \return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.
  * \return #kEtcPalErrInvalid: Invalid parameter provided.
@@ -121,14 +122,15 @@ void sacn_source_universe_config_init(SacnSourceUniverseConfig* config, uint16_t
  * \return #kEtcPalErrSys: An internal library or system call error occurred.
  */
 etcpal_error_t sacn_source_create(const SacnSourceConfig* config, sacn_source_t* handle,
-                                  SacnNetworkChangeResult* good_interfaces)
+                                  SacnMcastInterfaceToUse* ifaces, size_t ifaces_count)
 {
   // TODO CHRISTIAN
   // If the Tick thread hasn't been started yet, start it if the config isn't manual.
 
   ETCPAL_UNUSED_ARG(config);
   ETCPAL_UNUSED_ARG(handle);
-  ETCPAL_UNUSED_ARG(good_interfaces);
+  ETCPAL_UNUSED_ARG(ifaces);
+  ETCPAL_UNUSED_ARG(ifaces_count);
   return kEtcPalErrNotImpl;
 }
 
@@ -466,7 +468,7 @@ void sacn_source_set_dirty_and_force_sync(sacn_source_t handle, uint16_t univers
  * called by an internal thread of the module. Otherwise, this must be called at the maximum rate
  * at which the application will send sACN.
  *
- * Sends data for universes which have been marked dirty, and sends keep-alive data for universes which 
+ * Sends data for universes which have been marked dirty, and sends keep-alive data for universes which
  * haven't changed. Also destroys sources & universes that have been marked for termination after sending the required
  * three terminated packets.
  *
@@ -485,8 +487,8 @@ size_t sacn_source_process_sources(void)
  *
  * This is typically used when the application detects that the list of networking interfaces has changed.
  *
- * After this call completes successfully, all universes on a source are considered new & dirty by the
- * per-address priority logic in sacn_source_process_sources.
+ * After this call completes successfully, all universes on a source are considered to be dirty and have
+ * new values and priorities. It's as if the source just started sending values on that universe.
  *
  * If this call fails, the caller must call sacn_source_destroy(), because the source may be in an
  * invalid state.
@@ -495,11 +497,9 @@ size_t sacn_source_process_sources(void)
  * network interfaces passed in.  This will only return #kEtcPalErrNoNetints if none of the interfaces work.
  *
  * \param[in] handle Handle to the source for which to reset the networking.
- * \param[in] netints Optional array of network interfaces on which to send to the specified universe(s). If NULL,
- *  all available network interfaces will be used.
- * \param[in] num_netints Number of elements in the netints array.
- * \param[out] good_interfaces Optional. If non-NULL, good_interfaces is filled in with the list of network
- * interfaces that were succesfully used.
+ * \param[in, out] ifaces Optional. If non-NULL, this is the list of interfaces the application wants to use, and the
+ * operation_succeeded flags are filled in.  If NULL, all available interfaces are tried.
+ * \param[in, out] ifaces_count Optional. The size of ifaces, or 0 if ifaces is NULL.
  * \return #kEtcPalErrOk: Source changed successfully.
  * \return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.
  * \return #kEtcPalErrInvalid: Invalid parameter provided.
@@ -507,14 +507,12 @@ size_t sacn_source_process_sources(void)
  * \return #kEtcPalErrNotFound: Handle does not correspond to a valid source.
  * \return #kEtcPalErrSys: An internal library or system call error occurred.
  */
-etcpal_error_t sacn_source_reset_networking(sacn_source_t handle, const SacnMcastNetintId* netints, size_t num_netints,
-                                            SacnNetworkChangeResult* good_interfaces)
+etcpal_error_t sacn_source_reset_networking(sacn_source_t handle, SacnMcastInterfaceToUse* ifaces, size_t ifaces_count)
 {
   // TODO CHRISTIAN
   ETCPAL_UNUSED_ARG(handle);
-  ETCPAL_UNUSED_ARG(netints);
-  ETCPAL_UNUSED_ARG(num_netints);
-  ETCPAL_UNUSED_ARG(good_interfaces);
+  ETCPAL_UNUSED_ARG(ifaces);
+  ETCPAL_UNUSED_ARG(ifaces_count);
 
   return kEtcPalErrNotImpl;
 }

--- a/src/sacn/source.c
+++ b/src/sacn/source.c
@@ -64,12 +64,12 @@ void sacn_source_deinit(void)
   // Shut down the Tick thread...
 }
 
-/*!
- * \brief Initialize an sACN Source Config struct to default values.
+/**
+ * @brief Initialize an sACN Source Config struct to default values.
  *
- * \param[out] config Config struct to initialize.
- * \param[in] cid The CID to assign. Must not be NULL.
- * \param[in] name The source name to assign. Will be truncated to fit #SACN_SOURCE_NAME_MAX_LEN bytes.
+ * @param[out] config Config struct to initialize.
+ * @param[in] cid The CID to assign. Must not be NULL.
+ * @param[in] name The source name to assign. Will be truncated to fit #SACN_SOURCE_NAME_MAX_LEN bytes.
  */
 void sacn_source_config_init(SacnSourceConfig* config, const EtcPalUuid* cid, const char* name)
 {
@@ -79,14 +79,14 @@ void sacn_source_config_init(SacnSourceConfig* config, const EtcPalUuid* cid, co
   ETCPAL_UNUSED_ARG(name);
 }
 
-/*!
- * \brief Initialize an sACN Source Universe Config struct to default values.
+/**
+ * @brief Initialize an sACN Source Universe Config struct to default values.
  *
- * \param[out] config Config struct to initialize.
- * \param[in] universe The universe number to create.
- * \param[in] values_buffer The DMX values buffer, may not be NULL.
- * \param[in] values_len The length of values_buffer.
- * \param[in] priorities_buffer If non-NULL, holds the per-address priority buffer.
+ * @param[out] config Config struct to initialize.
+ * @param[in] universe The universe number to create.
+ * @param[in] values_buffer The DMX values buffer, may not be NULL.
+ * @param[in] values_len The length of values_buffer.
+ * @param[in] priorities_buffer If non-NULL, holds the per-address priority buffer.
  */
 void sacn_source_universe_config_init(SacnSourceUniverseConfig* config, uint16_t universe, const uint8_t* values_buffer,
                                       size_t values_len, const uint8_t* priorities_buffer)
@@ -99,8 +99,8 @@ void sacn_source_universe_config_init(SacnSourceUniverseConfig* config, uint16_t
   ETCPAL_UNUSED_ARG(priorities_buffer);
 }
 
-/*!
- * \brief Create a new sACN source to send sACN data.
+/**
+ * @brief Create a new sACN source to send sACN data.
  *
  * This creates the instance of the source, but no data is sent until sacn_source_add_universe() and
  * sacn_source_set_dirty() is called.
@@ -108,18 +108,18 @@ void sacn_source_universe_config_init(SacnSourceUniverseConfig* config, uint16_t
  * Note that a source is considered as successfully created if it is able to successfully use any of the
  * network interfaces passed in.  This will only return #kEtcPalErrNoNetints if none of the interfaces work.
  *
- * \param[in] config Configuration parameters for the sACN source to be created.
- * \param[out] handle Filled in on success with a handle to the sACN source.
- * \param[in, out] ifaces Optional. If non-NULL, this is the list of interfaces the application wants to use, and the
+ * @param[in] config Configuration parameters for the sACN source to be created.
+ * @param[out] handle Filled in on success with a handle to the sACN source.
+ * @param[in, out] ifaces Optional. If non-NULL, this is the list of interfaces the application wants to use, and the
  * operation_succeeded flags are filled in.  If NULL, all available interfaces are tried.
- * \param[in, out] ifaces_count Optional. The size of ifaces, or 0 if ifaces is NULL.
- * \return #kEtcPalErrOk: Source successfully created.
- * \return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.
- * \return #kEtcPalErrInvalid: Invalid parameter provided.
- * \return #kEtcPalErrNotInit: Module not initialized.
- * \return #kEtcPalErrNoMem: No room to allocate an additional source.
- * \return #kEtcPalErrNotFound: A network interface ID given was not found on the system.
- * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ * @param[in, out] ifaces_count Optional. The size of ifaces, or 0 if ifaces is NULL.
+ * @return #kEtcPalErrOk: Source successfully created.
+ * @return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.
+ * @return #kEtcPalErrInvalid: Invalid parameter provided.
+ * @return #kEtcPalErrNotInit: Module not initialized.
+ * @return #kEtcPalErrNoMem: No room to allocate an additional source.
+ * @return #kEtcPalErrNotFound: A network interface ID given was not found on the system.
+ * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
 etcpal_error_t sacn_source_create(const SacnSourceConfig* config, sacn_source_t* handle,
                                   SacnMcastInterfaceToUse* ifaces, size_t ifaces_count)
@@ -134,20 +134,20 @@ etcpal_error_t sacn_source_create(const SacnSourceConfig* config, sacn_source_t*
   return kEtcPalErrNotImpl;
 }
 
-/*!
- * \brief Change the name of an sACN source.
+/**
+ * @brief Change the name of an sACN source.
  *
  * The name is a UTF-8 string representing "a user-assigned name provided by the source of the
  * packet for use in displaying the identity of a source to a user." Only up to
  * #SACN_SOURCE_NAME_MAX_LEN characters will be used.
  *
- * \param[in] handle Handle to the source to change.
- * \param[in] new_name New name to use for this universe.
- * \return #kEtcPalErrOk: Name set successfully.
- * \return #kEtcPalErrInvalid: Invalid parameter provided.
- * \return #kEtcPalErrNotInit: Module not initialized.
- * \return #kEtcPalErrNotFound: Handle does not correspond to a valid source.
- * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ * @param[in] handle Handle to the source to change.
+ * @param[in] new_name New name to use for this universe.
+ * @return #kEtcPalErrOk: Name set successfully.
+ * @return #kEtcPalErrInvalid: Invalid parameter provided.
+ * @return #kEtcPalErrNotInit: Module not initialized.
+ * @return #kEtcPalErrNotFound: Handle does not correspond to a valid source.
+ * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
 etcpal_error_t sacn_source_change_name(sacn_source_t handle, const char* new_name)
 {
@@ -157,8 +157,8 @@ etcpal_error_t sacn_source_change_name(sacn_source_t handle, const char* new_nam
   return kEtcPalErrNotImpl;
 }
 
-/*!
- * \brief Destroy an sACN source instance.
+/**
+ * @brief Destroy an sACN source instance.
  *
  * Stops sending all universes for this source. The destruction is queued, and actually occurs
  * on a call to sacn_source_process_sources() after an additional three packets have been sent with the
@@ -167,7 +167,7 @@ etcpal_error_t sacn_source_change_name(sacn_source_t handle, const char* new_nam
  * Even though the destruction is queued, after this call the library will no longer use the priorities_buffer
  * or values_buffer you passed in on your call to sacn_source_add_universe().
  *
- * \param[in] handle Handle to the source to destroy.
+ * @param[in] handle Handle to the source to destroy.
  */
 void sacn_source_destroy(sacn_source_t handle)
 {
@@ -176,8 +176,8 @@ void sacn_source_destroy(sacn_source_t handle)
   ETCPAL_UNUSED_ARG(handle);
 }
 
-/*!
- * \brief Add a universe to an sACN source.
+/**
+ * @brief Add a universe to an sACN source.
  *
  * Adds a universe to a source.
  * After this call completes, the applicaton must call sacn_source_set_dirty() to mark it ready for processing.
@@ -185,15 +185,15 @@ void sacn_source_destroy(sacn_source_t handle)
  * If the source is not marked as unicast_only, the source will add the universe to its sACN Universe
  * Discovery packets.
 
- * \param[in] handle Handle to the source to which to add a universe.
- * \param[in] config Configuration parameters for the universe to be added.
- * \return #kEtcPalErrOk: Universe successfully added.
- * \return #kEtcPalErrInvalid: Invalid parameter provided.
- * \return #kEtcPalErrNotInit: Module not initialized.
- * \return #kEtcPalErrExists: Universe given was already added to this source.
- * \return #kEtcPalErrNotFound: Handle does not correspond to a valid source.
- * \return #kEtcPalErrNoMem: No room to allocate additional universe.
- * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ * @param[in] handle Handle to the source to which to add a universe.
+ * @param[in] config Configuration parameters for the universe to be added.
+ * @return #kEtcPalErrOk: Universe successfully added.
+ * @return #kEtcPalErrInvalid: Invalid parameter provided.
+ * @return #kEtcPalErrNotInit: Module not initialized.
+ * @return #kEtcPalErrExists: Universe given was already added to this source.
+ * @return #kEtcPalErrNotFound: Handle does not correspond to a valid source.
+ * @return #kEtcPalErrNoMem: No room to allocate additional universe.
+ * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
 etcpal_error_t sacn_source_add_universe(sacn_source_t handle, const SacnSourceUniverseConfig* config)
 {
@@ -204,8 +204,8 @@ etcpal_error_t sacn_source_add_universe(sacn_source_t handle, const SacnSourceUn
   return kEtcPalErrNotImpl;
 }
 
-/*!
- * \brief Remove a universe from a source.
+/**
+ * @brief Remove a universe from a source.
  *
  * This queues the source for removal. The destruction actually occurs
  * on a call to sacn_source_process_sources() after an additional three packets have been sent with the
@@ -216,8 +216,8 @@ etcpal_error_t sacn_source_add_universe(sacn_source_t handle, const SacnSourceUn
  * Even though the destruction is queued, after this call the library will no longer use the priorities_buffer
  * or values_buffer you passed in on your call to sacn_source_add_universe().
  *
- * \param[in] handle Handle to the source from which to remove the universe.
- * \param[in] universe Universe to remove.
+ * @param[in] handle Handle to the source from which to remove the universe.
+ * @param[in] universe Universe to remove.
  */
 void sacn_source_remove_universe(sacn_source_t handle, uint16_t universe)
 {
@@ -227,20 +227,20 @@ void sacn_source_remove_universe(sacn_source_t handle, uint16_t universe)
   ETCPAL_UNUSED_ARG(universe);
 }
 
-/*!
- * \brief Add a unicast destination for a source's universe.
+/**
+ * @brief Add a unicast destination for a source's universe.
  *
  * Adds a unicast destination for a source's universe.
  * After this call completes, the applicaton must call sacn_source_set_dirty() to mark it ready for processing.
  *
- * \param[in] handle Handle to the source to change.
- * \param[in] universe Universe to change.
- * \param[in] dest The destination IP.  May not be NULL.
- * \return #kEtcPalErrOk: Address added successfully.
- * \return #kEtcPalErrInvalid: Invalid parameter provided.
- * \return #kEtcPalErrNotInit: Module not initialized.
- * \return #kEtcPalErrNotFound: Handle does not correspond to a valid source or the universe is not on that source.
- * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ * @param[in] handle Handle to the source to change.
+ * @param[in] universe Universe to change.
+ * @param[in] dest The destination IP.  May not be NULL.
+ * @return #kEtcPalErrOk: Address added successfully.
+ * @return #kEtcPalErrInvalid: Invalid parameter provided.
+ * @return #kEtcPalErrNotInit: Module not initialized.
+ * @return #kEtcPalErrNotFound: Handle does not correspond to a valid source or the universe is not on that source.
+ * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
 etcpal_error_t sacn_source_add_unicast_destination(sacn_source_t handle, uint16_t universe, const EtcPalIpAddr* dest)
 {
@@ -252,16 +252,16 @@ etcpal_error_t sacn_source_add_unicast_destination(sacn_source_t handle, uint16_
   return kEtcPalErrNotImpl;
 }
 
-/*!
- * \brief Remove a unicast destination on a source's universe.
+/**
+ * @brief Remove a unicast destination on a source's universe.
  *
  * This queues the address for removal. The removal actually occurs
  * on a call to sacn_source_process_sources() after an additional three packets have been sent with the
  * "Stream_Terminated" option set.
  *
- * \param[in] handle Handle to the source to change.
- * \param[in] universe Universe to change.
- * \param[in] dest The destination IP.  May not be NULL, and must match the address passed to
+ * @param[in] handle Handle to the source to change.
+ * @param[in] universe Universe to change.
+ * @param[in] dest The destination IP.  May not be NULL, and must match the address passed to
  * sacn_source_add_unicast_destination().
  */
 void sacn_source_remove_unicast_destination(sacn_source_t handle, uint16_t universe, const EtcPalIpAddr* dest)
@@ -273,18 +273,18 @@ void sacn_source_remove_unicast_destination(sacn_source_t handle, uint16_t unive
   ETCPAL_UNUSED_ARG(dest);
 }
 
-/*!
- * \brief Change the priority of a universe on a sACN source.
+/**
+ * @brief Change the priority of a universe on a sACN source.
  *
- * \param[in] handle Handle to the source for which to set the priority.
- * \param[in] universe Universe to change.
- * \param[in] new_priority New priority of the data sent from this source. Valid range is 0 to 200,
+ * @param[in] handle Handle to the source for which to set the priority.
+ * @param[in] universe Universe to change.
+ * @param[in] new_priority New priority of the data sent from this source. Valid range is 0 to 200,
  *                         inclusive.
- * \return #kEtcPalErrOk: Priority set successfully.
- * \return #kEtcPalErrInvalid: Invalid parameter provided.
- * \return #kEtcPalErrNotInit: Module not initialized.
- * \return #kEtcPalErrNotFound: Handle does not correspond to a valid source or the universe is not on that source.
- * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ * @return #kEtcPalErrOk: Priority set successfully.
+ * @return #kEtcPalErrInvalid: Invalid parameter provided.
+ * @return #kEtcPalErrNotInit: Module not initialized.
+ * @return #kEtcPalErrNotFound: Handle does not correspond to a valid source or the universe is not on that source.
+ * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
 etcpal_error_t sacn_source_change_priority(sacn_source_t handle, uint16_t universe, uint8_t new_priority)
 {
@@ -296,20 +296,20 @@ etcpal_error_t sacn_source_change_priority(sacn_source_t handle, uint16_t univer
   return kEtcPalErrNotImpl;
 }
 
-/*!
- * \brief Change the sending_preview option on a universe of a sACN source.
+/**
+ * @brief Change the sending_preview option on a universe of a sACN source.
  *
  * Sets the state of a flag in the outgoing sACN packets that indicates that the data is (from
  * E1.31) "intended for use in visualization or media server preview applications and shall not be
  * used to generate live output."
  *
- * \param[in] handle Handle to the source for which to set the Preview_Data option.
- * \param[in] new_preview_flag The new sending_preview option.
- * \return #kEtcPalErrOk: sending_preview option set successfully.
- * \return #kEtcPalErrInvalid: Invalid parameter provided.
- * \return #kEtcPalErrNotInit: Module not initialized.
- * \return #kEtcPalErrNotFound: Handle does not correspond to a valid source or the universe is not on that source.
- * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ * @param[in] handle Handle to the source for which to set the Preview_Data option.
+ * @param[in] new_preview_flag The new sending_preview option.
+ * @return #kEtcPalErrOk: sending_preview option set successfully.
+ * @return #kEtcPalErrInvalid: Invalid parameter provided.
+ * @return #kEtcPalErrNotInit: Module not initialized.
+ * @return #kEtcPalErrNotFound: Handle does not correspond to a valid source or the universe is not on that source.
+ * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
 etcpal_error_t sacn_source_change_preview_flag(sacn_source_t handle, uint16_t universe, bool new_preview_flag)
 {
@@ -321,22 +321,22 @@ etcpal_error_t sacn_source_change_preview_flag(sacn_source_t handle, uint16_t un
   return kEtcPalErrNotImpl;
 }
 
-/*!
- * \brief Changes the synchronize uinverse for a universe of a sACN source.
+/**
+ * @brief Changes the synchronize uinverse for a universe of a sACN source.
  *
  * This will change the synchronization universe used by a sACN universe on the source.
  * If this value is 0, synchronization is turned off for that universe.
  *
  * TODO: At this time, synchronization is not supported by this library.
  *
- * \param[in] handle Handle to the source to change.
- * \param[in] universe The universe to change.
- * \param[in] new_sync_universe The new synchronization universe to set.
- * \return #kEtcPalErrOk: sync_universe set successfully.
- * \return #kEtcPalErrInvalid: Invalid parameter provided.
- * \return #kEtcPalErrNotInit: Module not initialized.
- * \return #kEtcPalErrNotFound: Handle does not correspond to a valid source or the universe is not on that source.
- * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ * @param[in] handle Handle to the source to change.
+ * @param[in] universe The universe to change.
+ * @param[in] new_sync_universe The new synchronization universe to set.
+ * @return #kEtcPalErrOk: sync_universe set successfully.
+ * @return #kEtcPalErrInvalid: Invalid parameter provided.
+ * @return #kEtcPalErrNotInit: Module not initialized.
+ * @return #kEtcPalErrNotFound: Handle does not correspond to a valid source or the universe is not on that source.
+ * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
 etcpal_error_t sacn_source_change_synchronization_universe(sacn_source_t handle, uint16_t universe,
                                                            uint16_t new_sync_universe)
@@ -349,24 +349,24 @@ etcpal_error_t sacn_source_change_synchronization_universe(sacn_source_t handle,
   return kEtcPalErrNotImpl;
 }
 
-/*!
- * \brief Immediately sends the provided sACN start code & data.
+/**
+ * @brief Immediately sends the provided sACN start code & data.
  *
  * Immediately sends a sACN packet with the provided start code and data.
  * This function is intended for sACN packets that have a startcode other than 0 or 0xdd, since those
  * start codes are taken care of by sacn_source_process_sources().
  *
- * \param[in] handle Handle to the source.
- * \param[in] universe Universe to send on.
- * \param[in] start_code The start code to send.
- * \param[in] buffer The buffer to send.  Must not be NULL.
- * \param[in] buflen The size of buffer.
- * \return #kEtcPalErrOk: Message successfully sent.
- * \return #kEtcPalErrInvalid: Invalid parameter provided.
- * \return #kEtcPalErrNotInit: Module not initialized.
- * \return #kEtcPalErrNotFound: Handle does not correspond to a valid source, or the universe was not found on this
+ * @param[in] handle Handle to the source.
+ * @param[in] universe Universe to send on.
+ * @param[in] start_code The start code to send.
+ * @param[in] buffer The buffer to send.  Must not be NULL.
+ * @param[in] buflen The size of buffer.
+ * @return #kEtcPalErrOk: Message successfully sent.
+ * @return #kEtcPalErrInvalid: Invalid parameter provided.
+ * @return #kEtcPalErrNotInit: Module not initialized.
+ * @return #kEtcPalErrNotFound: Handle does not correspond to a valid source, or the universe was not found on this
  *                              source.
- * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
 etcpal_error_t sacn_source_send_now(sacn_source_t handle, uint16_t universe, uint8_t start_code, const uint8_t* buffer,
                                     size_t buflen)
@@ -381,22 +381,22 @@ etcpal_error_t sacn_source_send_now(sacn_source_t handle, uint16_t universe, uin
   return kEtcPalErrNotImpl;
 }
 
-/*!
- * \brief Immediately sends a synchronization packet for the universe on a source.
+/**
+ * @brief Immediately sends a synchronization packet for the universe on a source.
  *
  * This will cause an immediate transmission of a synchronization packet for the source/universe.
  * If the universe does not have a synchronization universe configured, this call is ignored.
  *
  * TODO: At this time, synchronization is not supported by this library.
  *
- * \param[in] handle Handle to the source.
- * \param[in] universe Universe to send on.
- * \return #kEtcPalErrOk: Message successfully sent.
- * \return #kEtcPalErrInvalid: Invalid parameter provided.
- * \return #kEtcPalErrNotInit: Module not initialized.
- * \return #kEtcPalErrNotFound: Handle does not correspond to a valid source, or the universe was not found on this
+ * @param[in] handle Handle to the source.
+ * @param[in] universe Universe to send on.
+ * @return #kEtcPalErrOk: Message successfully sent.
+ * @return #kEtcPalErrInvalid: Invalid parameter provided.
+ * @return #kEtcPalErrNotInit: Module not initialized.
+ * @return #kEtcPalErrNotFound: Handle does not correspond to a valid source, or the universe was not found on this
  *                              source.
- * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
 etcpal_error_t sacn_source_send_synchronization(sacn_source_t handle, uint16_t universe)
 {
@@ -407,12 +407,12 @@ etcpal_error_t sacn_source_send_synchronization(sacn_source_t handle, uint16_t u
   return kEtcPalErrNotImpl;
 }
 
-/*!
- * \brief Indicate that the data in the buffer for this source and universe has changed and
+/**
+ * @brief Indicate that the data in the buffer for this source and universe has changed and
  *        should be sent on the next call to sacn_source_process_sources().
  *
- * \param[in] handle Handle to the source to mark as dirty.
- * \param[in] universe Universe to mark as dirty.
+ * @param[in] handle Handle to the source to mark as dirty.
+ * @param[in] universe Universe to mark as dirty.
  */
 void sacn_source_set_dirty(sacn_source_t handle, uint16_t universe)
 {
@@ -422,13 +422,13 @@ void sacn_source_set_dirty(sacn_source_t handle, uint16_t universe)
   ETCPAL_UNUSED_ARG(universe);
 }
 
-/*!
- * \brief Indicate that the data in the buffers for a list of universes on a source  has
+/**
+ * @brief Indicate that the data in the buffers for a list of universes on a source  has
  *        changed and should be sent on the next call to sacn_source_process_sources().
  *
- * \param[in] handle Handle to the source.
- * \param[in] universes Array of universes to mark as dirty. Must not be NULL.
- * \param[in] num_universes Size of the universes array.
+ * @param[in] handle Handle to the source.
+ * @param[in] universes Array of universes to mark as dirty. Must not be NULL.
+ * @param[in] num_universes Size of the universes array.
  */
 void sacn_source_set_list_dirty(sacn_source_t handle, const uint16_t* universes, size_t num_universes)
 {
@@ -439,8 +439,8 @@ void sacn_source_set_list_dirty(sacn_source_t handle, const uint16_t* universes,
   ETCPAL_UNUSED_ARG(num_universes);
 }
 
-/*!
- * \brief Like sacn_source_set_dirty, but also sets the force_sync flag on the packet.
+/*@
+ * @brief Like sacn_source_set_dirty, but also sets the force_sync flag on the packet.
  *
  * This function indicates that the data in the buffer for this source and universe has changed,
  * and should be sent on the next call to sacn_source_process_sources().  Additionally, the packet
@@ -450,8 +450,8 @@ void sacn_source_set_list_dirty(sacn_source_t handle, const uint16_t* universes,
  *
  * TODO: At this time, synchronization is not supported by this library.
  *
- * \param[in] handle Handle to the source to mark as dirty.
- * \param[in] universe Universe to mark as dirty.
+ * @param[in] handle Handle to the source to mark as dirty.
+ * @param[in] universe Universe to mark as dirty.
  */
 void sacn_source_set_dirty_and_force_sync(sacn_source_t handle, uint16_t universe)
 {
@@ -461,8 +461,8 @@ void sacn_source_set_dirty_and_force_sync(sacn_source_t handle, uint16_t univers
   ETCPAL_UNUSED_ARG(universe);
 }
 
-/*!
- * \brief Process created sources and do the actual sending of sACN data on all universes.
+/**
+ * @brief Process created sources and do the actual sending of sACN data on all universes.
  *
  * Note: Unless you created the source with manually_process_source set to true, this will be automatically
  * called by an internal thread of the module. Otherwise, this must be called at the maximum rate
@@ -472,7 +472,7 @@ void sacn_source_set_dirty_and_force_sync(sacn_source_t handle, uint16_t univers
  * haven't changed. Also destroys sources & universes that have been marked for termination after sending the required
  * three terminated packets.
  *
- * \return Current number of sources tracked by the library. This can be useful on shutdown to
+ * @return Current number of sources tracked by the library. This can be useful on shutdown to
  *         track when destroyed sources have finished sending the terminated packets and actually
  *         been destroyed.
  */
@@ -482,8 +482,8 @@ size_t sacn_source_process_sources(void)
   return 0;
 }
 
-/*!
- * \brief Resets the underlying network sockets for the sACN source.
+/**
+ * @brief Resets the underlying network sockets for the sACN source.
  *
  * This is typically used when the application detects that the list of networking interfaces has changed.
  *
@@ -496,16 +496,16 @@ size_t sacn_source_process_sources(void)
  * Note that the networking reset is considered successful if it is able to successfully use any of the
  * network interfaces passed in.  This will only return #kEtcPalErrNoNetints if none of the interfaces work.
  *
- * \param[in] handle Handle to the source for which to reset the networking.
- * \param[in, out] ifaces Optional. If non-NULL, this is the list of interfaces the application wants to use, and the
+ * @param[in] handle Handle to the source for which to reset the networking.
+ * @param[in, out] ifaces Optional. If non-NULL, this is the list of interfaces the application wants to use, and the
  * operation_succeeded flags are filled in.  If NULL, all available interfaces are tried.
- * \param[in, out] ifaces_count Optional. The size of ifaces, or 0 if ifaces is NULL.
- * \return #kEtcPalErrOk: Source changed successfully.
- * \return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.
- * \return #kEtcPalErrInvalid: Invalid parameter provided.
- * \return #kEtcPalErrNotInit: Module not initialized.
- * \return #kEtcPalErrNotFound: Handle does not correspond to a valid source.
- * \return #kEtcPalErrSys: An internal library or system call error occurred.
+ * @param[in, out] ifaces_count Optional. The size of ifaces, or 0 if ifaces is NULL.
+ * @return #kEtcPalErrOk: Source changed successfully.
+ * @return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.
+ * @return #kEtcPalErrInvalid: Invalid parameter provided.
+ * @return #kEtcPalErrNotInit: Module not initialized.
+ * @return #kEtcPalErrNotFound: Handle does not correspond to a valid source.
+ * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
 etcpal_error_t sacn_source_reset_networking(sacn_source_t handle, SacnMcastInterfaceToUse* ifaces, size_t ifaces_count)
 {

--- a/src/sacn/source.c
+++ b/src/sacn/source.c
@@ -177,16 +177,14 @@ void sacn_source_destroy(sacn_source_t handle)
 /*!
  * \brief Add a universe to an sACN source.
  *
- * Adds a universe to a source. If dirty_now is true, the source will start sending values on the
- * next call to sacn_source_process_sources(). If dirty_now is false, the applicaton must call sacn_source_set_dirty()
- * to mark it ready for processing.
+ * Adds a universe to a source.
+ * After this call completes, the applicaton must call sacn_source_set_dirty() to mark it ready for processing.
  *
  * If the source is not marked as unicast_only, the source will add the universe to its sACN Universe
  * Discovery packets.
 
  * \param[in] handle Handle to the source to which to add a universe.
  * \param[in] config Configuration parameters for the universe to be added.
- * \param[in] dirty_now Whether or not to immediately mark the universe as dirty.
  * \return #kEtcPalErrOk: Universe successfully added.
  * \return #kEtcPalErrInvalid: Invalid parameter provided.
  * \return #kEtcPalErrNotInit: Module not initialized.
@@ -195,13 +193,12 @@ void sacn_source_destroy(sacn_source_t handle)
  * \return #kEtcPalErrNoMem: No room to allocate additional universe.
  * \return #kEtcPalErrSys: An internal library or system call error occurred.
  */
-etcpal_error_t sacn_source_add_universe(sacn_source_t handle, const SacnSourceUniverseConfig* config, bool dirty_now)
+etcpal_error_t sacn_source_add_universe(sacn_source_t handle, const SacnSourceUniverseConfig* config)
 {
   // TODO CHRISTIAN
 
   ETCPAL_UNUSED_ARG(handle);
   ETCPAL_UNUSED_ARG(config);
-  ETCPAL_UNUSED_ARG(dirty_now);
   return kEtcPalErrNotImpl;
 }
 
@@ -231,25 +228,25 @@ void sacn_source_remove_universe(sacn_source_t handle, uint16_t universe)
 /*!
  * \brief Add a unicast destination for a source's universe.
  *
+ * Adds a unicast destination for a source's universe.
+ * After this call completes, the applicaton must call sacn_source_set_dirty() to mark it ready for processing.
+ *
  * \param[in] handle Handle to the source to change.
  * \param[in] universe Universe to change.
  * \param[in] dest The destination IP.  May not be NULL.
- * \param[in] dirty_now Whether or not to mark it dirty for the next sacn_source_process_sources() call.
  * \return #kEtcPalErrOk: Address added successfully.
  * \return #kEtcPalErrInvalid: Invalid parameter provided.
  * \return #kEtcPalErrNotInit: Module not initialized.
  * \return #kEtcPalErrNotFound: Handle does not correspond to a valid source or the universe is not on that source.
  * \return #kEtcPalErrSys: An internal library or system call error occurred.
  */
-etcpal_error_t sacn_source_add_unicast_destination(sacn_source_t handle, uint16_t universe, const EtcPalIpAddr* dest,
-                                                   bool dirty_now)
+etcpal_error_t sacn_source_add_unicast_destination(sacn_source_t handle, uint16_t universe, const EtcPalIpAddr* dest)
 {
   // TODO CHRISTIAN
 
   ETCPAL_UNUSED_ARG(handle);
   ETCPAL_UNUSED_ARG(universe);
   ETCPAL_UNUSED_ARG(dest);
-  ETCPAL_UNUSED_ARG(dirty_now);
   return kEtcPalErrNotImpl;
 }
 

--- a/src/sacn/source.c
+++ b/src/sacn/source.c
@@ -21,7 +21,7 @@
  - Make sure I didn't miss any requirements or details from the protocol.
  - A whole lotta implementation.  You should be able to base some this on the earlier C++ library, but also look at the
  spec for 0xdd, since the old library didn't handle intermixing 0x00 & 0xdd on take-control and release-control.  Ray
- can help there, too.
+ can help there, too. This will probably be the largest portion of testing..
  - Get usage/API documentation in place and cleaned up so we can have a larger review.
  - Make sure everything works with static & dynamic memory.
  - This entire project should build without warnings!!

--- a/src/sacn/source.c
+++ b/src/sacn/source.c
@@ -17,6 +17,28 @@
  * https://github.com/ETCLabs/sACN
  *****************************************************************************/
 
+/*********** CHRISTIAN's BIG OL' TODO LIST: *************************************
+ - Get usage/API documentation in place and cleaned up so we can have a larger review.
+ - Make sure everything works with static & dynamic memory.
+ --------------NICK CLEAN UP
+ - Add EtcPalMcastNetintId to EtcPal, and remove struct SacnMcastNetintId and RdmnetMcastNetintId
+ - I've added the universe to all the callbacks.  Make sure the notification structs are initialized and work correctly for all notifications.
+ - Add full support for the sources found notification. Packets aren't forwarded to the application until the source list is stable.
+ - Add unicast support to sockets.c in the SACN_RECEIVER_SOCKET_PER_UNIVERSE case.
+ - Make sure unicast support works in both socket modes, with one or more receivers created.
+ - Make sure everything works with static & dynamic memory.
+ - Make source addition honors source_count_max, even in dynamic mode.
+ - Start Codes that aren't 0 & 0xdd should still get forwarded to the application in handle_sacn_data_packet!
+ - refactor common.c's init & deinit functions to be more similar to https://github.com/ETCLabs/RDMnet/blob/develop/src/rdmnet/core/common.c#L141's functions, as Sam put in the review. 
+ - Make the example receiver use the new api.
+ - Make an example receiver & testing for the c++ header.
+ - IPv6 support.  See the CHRISTIAN TODO IPV6 comments for some hints on where to change.
+ - Make sure draft support works properly.  If a source is sending both draft and ratified, the sequence numbers should
+   filter out the duplicate packet (just like IPv4 & IPv6).
+ - This entire project should build without warnings!!
+ - Sync support.  Update TODO comments in receiver & merge_receiver that state sync isn't supported.
+*/
+
 #include "sacn/source.h"
 
 /****************************** Private macros *******************************/

--- a/src/sacn/source.c
+++ b/src/sacn/source.c
@@ -89,14 +89,14 @@ void sacn_source_config_init(SacnSourceConfig* config, const EtcPalUuid* cid, co
  * \param[in] priorities_buffer If non-NULL, holds the per-address priority buffer.
  */
 void sacn_source_universe_config_init(SacnSourceUniverseConfig* config, uint16_t universe, const uint8_t* values_buffer,
-                                      size_t values_len, const uint8_t* priority_buffer)
+                                      size_t values_len, const uint8_t* priorities_buffer)
 {
   // TODO CHRISTIAN
   ETCPAL_UNUSED_ARG(config);
   ETCPAL_UNUSED_ARG(universe);
   ETCPAL_UNUSED_ARG(values_buffer);
   ETCPAL_UNUSED_ARG(values_len);
-  ETCPAL_UNUSED_ARG(priority_buffer);
+  ETCPAL_UNUSED_ARG(priorities_buffer);
 }
 
 /*!
@@ -162,7 +162,7 @@ etcpal_error_t sacn_source_change_name(sacn_source_t handle, const char* new_nam
  * on a call to sacn_source_process_sources() after an additional three packets have been sent with the
  * "Stream_Terminated" option set. The source will also stop transmitting sACN universe discovery packets.
  *
- * Even though the destruction is queued, after this call the library will no longer use the priority_buffer
+ * Even though the destruction is queued, after this call the library will no longer use the priorities_buffer
  * or values_buffer you passed in on your call to sacn_source_add_universe().
  *
  * \param[in] handle Handle to the source to destroy.
@@ -214,10 +214,10 @@ etcpal_error_t sacn_source_add_universe(sacn_source_t handle, const SacnSourceUn
  *
  * The source will also stop transmitting sACN universe discovery packets for that universe.
  *
- * Even though the destruction is queued, after this call the library will no longer use the priority_buffer
+ * Even though the destruction is queued, after this call the library will no longer use the priorities_buffer
  * or values_buffer you passed in on your call to sacn_source_add_universe().
  *
- * \param[in] handle Handle to the source from which to remove the start code.
+ * \param[in] handle Handle to the source from which to remove the universe.
  * \param[in] universe Universe to remove.
  */
 void sacn_source_remove_universe(sacn_source_t handle, uint16_t universe)
@@ -469,7 +469,7 @@ void sacn_source_set_dirty_and_force_sync(sacn_source_t handle, uint16_t univers
  * called by an internal thread of the module. Otherwise, this must be called at the maximum rate
  * at which the application will send sACN.
  *
- * Sends data for universes which have been marked dirty, and sends keep-alive data for universes which are
+ * Sends data for universes which have been marked dirty, and sends keep-alive data for universes which 
  * haven't changed. Also destroys sources & universes that have been marked for termination after sending the required
  * three terminated packets.
  *
@@ -498,7 +498,7 @@ size_t sacn_source_process_sources(void)
  * network interfaces passed in.  This will only return #kEtcPalErrNoNetints if none of the interfaces work.
  *
  * \param[in] handle Handle to the source for which to reset the networking.
- * \param[in] netints Optional array of network interfaces on which to send to the specified universe. If NULL,
+ * \param[in] netints Optional array of network interfaces on which to send to the specified universe(s). If NULL,
  *  all available network interfaces will be used.
  * \param[in] num_netints Number of elements in the netints array.
  * \param[out] good_interfaces Optional. If non-NULL, good_interfaces is filled in with the list of network
@@ -507,7 +507,7 @@ size_t sacn_source_process_sources(void)
  * \return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.
  * \return #kEtcPalErrInvalid: Invalid parameter provided.
  * \return #kEtcPalErrNotInit: Module not initialized.
- * \return #kEtcPalErrNotFound: Handle does not correspond to a valid receiver.
+ * \return #kEtcPalErrNotFound: Handle does not correspond to a valid source.
  * \return #kEtcPalErrSys: An internal library or system call error occurred.
  */
 etcpal_error_t sacn_source_reset_networking(sacn_source_t handle, const SacnMcastNetintId* netints, size_t num_netints,

--- a/src/sacn/source.c
+++ b/src/sacn/source.c
@@ -30,7 +30,6 @@
  - IPv6 support.
  - Sync support.  Update TODO comments in source.h & .c that state sync isn't supported.
  --------------NICK CLEAN UP
- - C++ headers & initial test framework
  - RE-EXAMINE!!!!! -- The C++ headers should return the working interfaces on Create and Reset!!!!
  - Flesh out Draft API, and make C++ interface that can encompass both draft & ratified!!!
  - DRAFT SUPPORT can this just be a flag (send draft in addition to ratified?) Check requirements!!
@@ -115,7 +114,7 @@ void sacn_source_universe_config_init(SacnSourceUniverseConfig* config, uint16_t
  *
  * \param[in] config Configuration parameters for the sACN source to be created.
  * \param[out] handle Filled in on success with a handle to the sACN source.
- * \param[in, out] good_interfaces Optional. If non-NULL, good_interfaces is filled in with the list of network
+ * \param[out] good_interfaces Optional. If non-NULL, good_interfaces is filled in with the list of network
  * interfaces that were succesfully used.
  * \return #kEtcPalErrOk: Source successfully created.
  * \return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.
@@ -506,7 +505,7 @@ size_t sacn_source_process_sources(void)
  * \param[in] netints Optional array of network interfaces on which to send to the specified universe. If NULL,
  *  all available network interfaces will be used.
  * \param[in] num_netints Number of elements in the netints array.
- * \param[in, out] good_interfaces Optional. If non-NULL, good_interfaces is filled in with the list of network
+ * \param[out] good_interfaces Optional. If non-NULL, good_interfaces is filled in with the list of network
  * interfaces that were succesfully used.
  * \return #kEtcPalErrOk: Source changed successfully.
  * \return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.

--- a/tests/unit/api/c/receiver/test_receiver.cpp
+++ b/tests/unit/api/c/receiver/test_receiver.cpp
@@ -111,7 +111,7 @@ TEST_F(TestReceiver, ChangeUniverseWorks)
   };
 
   sacn_receiver_t handle;
-  sacn_receiver_create(&config, &handle);
+  sacn_receiver_create(&config, &handle, nullptr);
 
   clear_term_set_list_fake.custom_fake = [](TerminationSet* list) { EXPECT_EQ(list, nullptr); };
   sacn_remove_receiver_socket_fake.custom_fake = [](sacn_thread_id_t thread_id, etcpal_socket_t socket, bool) {
@@ -184,12 +184,12 @@ TEST_F(TestReceiver, ChangeUniverseErrExistsWorks)
   config.universe_id = CHANGE_UNIVERSE_RECEIVER_EXISTS_UNIVERSE;
 
   sacn_receiver_t handle_existing_receiver;
-  sacn_receiver_create(&config, &handle_existing_receiver);
+  sacn_receiver_create(&config, &handle_existing_receiver, nullptr);
 
   config.universe_id = CHANGE_UNIVERSE_NO_RECEIVER_UNIVERSE_1;
 
   sacn_receiver_t handle_changing_receiver;
-  sacn_receiver_create(&config, &handle_changing_receiver);
+  sacn_receiver_create(&config, &handle_changing_receiver, nullptr);
 
   etcpal_error_t change_universe_no_err_exists_result =
       sacn_receiver_change_universe(handle_changing_receiver, CHANGE_UNIVERSE_NO_RECEIVER_UNIVERSE_2);
@@ -213,7 +213,7 @@ TEST_F(TestReceiver, ChangeUniverseErrNotFoundWorks)
   config.universe_id = CHANGE_UNIVERSE_VALID_UNIVERSE_1;
 
   sacn_receiver_t handle;
-  sacn_receiver_create(&config, &handle);
+  sacn_receiver_create(&config, &handle, nullptr);
 
   etcpal_error_t change_universe_found_result =
       sacn_receiver_change_universe(handle, CHANGE_UNIVERSE_VALID_UNIVERSE_2);

--- a/tests/unit/api/c/receiver/test_receiver.cpp
+++ b/tests/unit/api/c/receiver/test_receiver.cpp
@@ -111,7 +111,7 @@ TEST_F(TestReceiver, ChangeUniverseWorks)
   };
 
   sacn_receiver_t handle;
-  sacn_receiver_create(&config, &handle, nullptr);
+  sacn_receiver_create(&config, &handle, nullptr, 0);
 
   clear_term_set_list_fake.custom_fake = [](TerminationSet* list) { EXPECT_EQ(list, nullptr); };
   sacn_remove_receiver_socket_fake.custom_fake = [](sacn_thread_id_t thread_id, etcpal_socket_t socket, bool) {
@@ -184,12 +184,12 @@ TEST_F(TestReceiver, ChangeUniverseErrExistsWorks)
   config.universe_id = CHANGE_UNIVERSE_RECEIVER_EXISTS_UNIVERSE;
 
   sacn_receiver_t handle_existing_receiver;
-  sacn_receiver_create(&config, &handle_existing_receiver, nullptr);
+  sacn_receiver_create(&config, &handle_existing_receiver, nullptr, 0);
 
   config.universe_id = CHANGE_UNIVERSE_NO_RECEIVER_UNIVERSE_1;
 
   sacn_receiver_t handle_changing_receiver;
-  sacn_receiver_create(&config, &handle_changing_receiver, nullptr);
+  sacn_receiver_create(&config, &handle_changing_receiver, nullptr, 0);
 
   etcpal_error_t change_universe_no_err_exists_result =
       sacn_receiver_change_universe(handle_changing_receiver, CHANGE_UNIVERSE_NO_RECEIVER_UNIVERSE_2);
@@ -213,7 +213,7 @@ TEST_F(TestReceiver, ChangeUniverseErrNotFoundWorks)
   config.universe_id = CHANGE_UNIVERSE_VALID_UNIVERSE_1;
 
   sacn_receiver_t handle;
-  sacn_receiver_create(&config, &handle, nullptr);
+  sacn_receiver_create(&config, &handle, nullptr, 0);
 
   etcpal_error_t change_universe_found_result =
       sacn_receiver_change_universe(handle, CHANGE_UNIVERSE_VALID_UNIVERSE_2);

--- a/tests/unit/api/cpp/CMakeLists.txt
+++ b/tests/unit/api/cpp/CMakeLists.txt
@@ -3,3 +3,4 @@
 add_subdirectory(merge_receiver)
 add_subdirectory(merger)
 add_subdirectory(receiver)
+add_subdirectory(source)

--- a/tests/unit/api/cpp/source/CMakeLists.txt
+++ b/tests/unit/api/cpp/source/CMakeLists.txt
@@ -1,0 +1,12 @@
+# sACN C++ Source API unit tests
+
+set(TEST_SOURCE_SOURCES
+  test_cpp_source.cpp
+  main.cpp
+
+  ${SACN_API_SOURCES}
+  ${SACN_MOCK_SOURCES}
+)
+
+sacn_add_dynamic_test(test_cpp_source ${TEST_SOURCE_SOURCES})
+sacn_add_static_test(test_cpp_source ${TEST_SOURCE_SOURCES})

--- a/tests/unit/api/cpp/source/main.cpp
+++ b/tests/unit/api/cpp/source/main.cpp
@@ -1,0 +1,35 @@
+/******************************************************************************
+ * Copyright 2020 ETC Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************
+ * This file is a part of sACN. For more information, go to:
+ * https://github.com/ETCLabs/sACN
+ *****************************************************************************/
+
+#include "gtest/gtest.h"
+#include "fff.h"
+
+DEFINE_FFF_GLOBALS;
+
+extern "C" void SacnTestingAssertHandler(const char* expression, const char* file, unsigned int line)
+{
+  FAIL() << "Assertion failure from inside sACN library. Expression: " << expression << " File: " << file
+         << " Line: " << line;
+}
+
+int main(int argc, char* argv[])
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/tests/unit/api/cpp/source/test_cpp_source.cpp
+++ b/tests/unit/api/cpp/source/test_cpp_source.cpp
@@ -31,13 +31,13 @@
 #include "gtest/gtest.h"
 
 #if SACN_DYNAMIC_MEM
-#define TestReceiver TestCppReceiverDynamic
+#define TestSource TestCppSourceDynamic
 #else
-#define TestReceiver TestCppReceiverStatic
+#define TestSource TestCppSourceStatic
 #endif
 
 
-class TestReceiver : public ::testing::Test
+class TestSource : public ::testing::Test
 {
 protected:
   void SetUp() override
@@ -58,7 +58,7 @@ protected:
   }
 };
 
-TEST_F(TestReceiver, SetStandardVersionWorks)
+TEST_F(TestSource, SetStandardVersionWorks)
 {
   //CHRISTIAN TODO: CLEAN UP TESTING
 }

--- a/tests/unit/api/cpp/source/test_cpp_source.cpp
+++ b/tests/unit/api/cpp/source/test_cpp_source.cpp
@@ -1,0 +1,64 @@
+/******************************************************************************
+ * Copyright 2020 ETC Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************
+ * This file is a part of sACN. For more information, go to:
+ * https://github.com/ETCLabs/sACN
+ *****************************************************************************/
+
+#include "sacn/cpp/common.h"
+#include "sacn/cpp/source.h"
+
+#include <limits>
+#include "etcpal_mock/common.h"
+#include "sacn_mock/private/common.h"
+#include "sacn_mock/private/data_loss.h"
+#include "sacn_mock/private/sockets.h"
+#include "sacn/private/mem.h"
+#include "sacn/private/opts.h"
+#include "sacn/private/source.h"
+#include "gtest/gtest.h"
+
+#if SACN_DYNAMIC_MEM
+#define TestReceiver TestCppReceiverDynamic
+#else
+#define TestReceiver TestCppReceiverStatic
+#endif
+
+
+class TestReceiver : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    etcpal_reset_all_fakes();
+    sacn_common_reset_all_fakes();
+    sacn_data_loss_reset_all_fakes();
+    sacn_sockets_reset_all_fakes();
+
+    ASSERT_EQ(sacn_mem_init(1), kEtcPalErrOk);
+    ASSERT_EQ(sacn_source_init(), kEtcPalErrOk);
+  }
+
+  void TearDown() override
+  {
+    sacn_source_deinit();
+    sacn_mem_deinit();
+  }
+};
+
+TEST_F(TestReceiver, SetStandardVersionWorks)
+{
+  //CHRISTIAN TODO: CLEAN UP TESTING
+}

--- a/tools/version/templates/version.h.in
+++ b/tools/version/templates/version.h.in
@@ -17,9 +17,9 @@
  * https://github.com/ETCLabs/sACN
  *****************************************************************************/
 
-/*!
- * \file sacn/version.h
- * \brief Provides the current version of the sACN library.
+/**
+ * @file sacn/version.h
+ * @brief Provides the current version of the sACN library.
  *
  * This file is provided for application use; the values defined in this file are not used
  * internally by the library.
@@ -30,36 +30,36 @@
 
 /* clang-format off */
 
-/*!
- * \addtogroup sACN
+/**
+ * @addtogroup sACN
  * @{
  */
 
-/*!
- * \name sACN version numbers
+/**
+ * @name sACN version numbers
  * @{
  */
-#define SACN_VERSION_MAJOR @SACN_VERSION_MAJOR@ /*!< The major version. */
-#define SACN_VERSION_MINOR @SACN_VERSION_MINOR@ /*!< The minor version. */
-#define SACN_VERSION_PATCH @SACN_VERSION_PATCH@ /*!< The patch version. */
-#define SACN_VERSION_BUILD @SACN_VERSION_BUILD@ /*!< The build number. */
-/*!
+#define SACN_VERSION_MAJOR @SACN_VERSION_MAJOR@ /**< The major version. */
+#define SACN_VERSION_MINOR @SACN_VERSION_MINOR@ /**< The minor version. */
+#define SACN_VERSION_PATCH @SACN_VERSION_PATCH@ /**< The patch version. */
+#define SACN_VERSION_BUILD @SACN_VERSION_BUILD@ /**< The build number. */
+/**
  * @}
  */
 
-/*!
- * \name sACN version strings
+/**
+ * @name sACN version strings
  * @{
  */
 #define SACN_VERSION_STRING      "@SACN_VERSION_STRING@"
 #define SACN_VERSION_DATESTR     "@SACN_VERSION_DATESTR@"
 #define SACN_VERSION_COPYRIGHT   "@SACN_VERSION_COPYRIGHT@"
 #define SACN_VERSION_PRODUCTNAME "sACN"
-/*!
+/**
  * @}
  */
 
-/*!
+/**
  * @}
  */
 


### PR DESCRIPTION
This is my initial proposal for the ratified sACN source API. Above and beyond this review, there are a couple of issues to think about.

1) Because draft is not transmitted by this library, we don't control draft source sequence numbers. Do we need to worry about an ETC device sourcing both draft & ratified for the same universe? I really don't want to have to put filtering in the receive side for this case, since it should be rare. I'm going to ping Ray on this one, too.
2) I'm having difficulty thinking of an abstract interface class for the sACN source that would provide something like Eos is looking for and still be useful. Or even make sense to be exposed in open source. Maybe that group would need to create their own layer for their own needs, or this is something additional we could provide. Again, I'll ping Ray.