### PR TITLE
Fixing initial documentation warnings.

### DIFF
--- a/docs/pages/mainpage.md
+++ b/docs/pages/mainpage.md
@@ -2,15 +2,10 @@
 
 ## Introduction
 
-*Streaming ACN (sACN)* is an ANSI standard for entertainment technology by
-[ESTA](http://tsp.esta.org) for transmission of DMX512 data over IP networks. sACN is widely used
-in the entertainment industry for real-time control of entertainment technology, especially
-lighting fixtures.
-
-This repository contains a C-language library and a C++ wrapper library for communicating via sACN.
-
-**NOTE**: This open-source implementation is still in development. The merge receiver, source, and
-source detector have not been implemented yet.
+sACN is a C-language library (with C++ wrappers) that implements **ANSI E1.31: Lightweight streaming protocol for
+transport of DMX512 using ACN**, commonly referred to as **Streaming ACN** or **sACN**. The sACN
+library is designed to be portable and scalable to almost any sACN usage scenario, from lightweight
+embedded devices to large-scale data sending operations.
 
 Check out \ref getting_started to get started with using the library in your application. To jump
 right into the documentation, check out the [Modules Overview](\ref sACN).

--- a/docs/pages/mainpage.md
+++ b/docs/pages/mainpage.md
@@ -2,13 +2,15 @@
 
 ## Introduction
 
-sACN is a C-language library that implements **ANSI E1.31: Lightweight streaming protocol for
-transport of DMX512 using ACN**, commonly referred to as **Streaming ACN** or **sACN**. The sACN
-library is designed to be portable and scalable to almost any sACN usage scenario, from lightweight
-embedded devices to large-scale data sending operations.
+*Streaming ACN (sACN)* is an ANSI standard for entertainment technology by
+[ESTA](http://tsp.esta.org) for transmission of DMX512 data over IP networks. sACN is widely used
+in the entertainment industry for real-time control of entertainment technology, especially
+lighting fixtures.
 
-**NOTE**: This open-source implementation is still early in development, and currently only
-receiving sACN is implemented.
+This repository contains a C-language library and a C++ wrapper library for communicating via sACN.
+
+**NOTE**: This open-source implementation is still in development. The merge receiver, source, and
+source detector have not been implemented yet.
 
 Check out \ref getting_started to get started with using the library in your application. To jump
 right into the documentation, check out the [Modules Overview](\ref sACN).

--- a/docs/pages/using_source.md
+++ b/docs/pages/using_source.md
@@ -48,7 +48,7 @@ etcpal::Uuid my_cid;
 std::string my_name;
 // Assuming my_cid and my_name are initialized by the application...
 
-Settings my_config(my_cid, my_name);
+sacn::Source::Settings my_config(my_cid, my_name);
 
 std::vector<SacnMcastInterface> my_netints;
 // Assuming my_netints is initialized by the application...
@@ -108,7 +108,7 @@ uint8_t my_priorities_buffer[DMX_ADDRESS_COUNT];
 
 uint16_t my_universe = 1;  // Using universe 1 as an example.
 
-UniverseSettings my_universe_config(my_universe, my_values_buffer, DMX_ADDRESS_COUNT);
+sacn::Source::UniverseSettings my_universe_config(my_universe, my_values_buffer, DMX_ADDRESS_COUNT);
 // If you want per-address priorities:
 my_universe_config.priorities_buffer = my_priorities_buffer;
 // Otherwise, specify a universe priority:

--- a/include/sacn/common.h
+++ b/include/sacn/common.h
@@ -92,9 +92,9 @@ typedef struct SacnHeaderData
 } SacnHeaderData;
 
 /**
-* On input, this structure is used to indicate a network interface to use.
-* On output, this structure indicates whether or not the operation was a success.
-*/
+ * On input, this structure is used to indicate a network interface to use.
+ * On output, this structure indicates whether or not the operation was a success.
+ */
 typedef struct SacnMcastInterface
 {
   /**

--- a/include/sacn/common.h
+++ b/include/sacn/common.h
@@ -97,7 +97,13 @@ typedef struct SacnHeaderData
 */
 typedef struct SacnMcastInterface
 {
+  /**
+   * The multicast interface to use.
+   */
   EtcPalMcastNetintId iface;
+  /**
+   * Whether or not the multicast interface was useable.
+   */
   bool operation_succeeded;
 } SacnMcastInterface;
 

--- a/include/sacn/cpp/dmx_merger.h
+++ b/include/sacn/cpp/dmx_merger.h
@@ -87,7 +87,7 @@ public:
     uint8_t* per_address_priorities{nullptr};
 
     /** Buffer of #DMX_ADDRESS_COUNT source IDs that indicate the current winner of the merge for that slot, or
-        #DMX_MERGER_SOURCE_INVALID to indicate that no source is providing values for that slot. This is used if you
+        #SACN_DMX_MERGER_SOURCE_INVALID to indicate that no source is providing values for that slot. This is used if you
         need to know the source of each slot. If you only need to know whether or not a slot is sourced, set this to
         NULL and use per_address_priorities (which has half the memory footprint) to check if the slot has a priority of
         0 (not sourced).
@@ -152,7 +152,7 @@ inline bool DmxMerger::Settings::IsValid() const
  * Creates a new merger that uses the passed in config data.  The application owns all buffers
  * in the config, so be sure to call Shutdown() before destroying the buffers.
  *
- * @param[in] config Configuration parameters for the DMX merger to be created.
+ * @param[in] settings Configuration parameters for the DMX merger to be created.
  * @return #kEtcPalErrOk: Merger created successful.
  * @return #kEtcPalErrInvalid: Invalid parameter provided.
  * @return #kEtcPalErrNotInit: Module not initialized.

--- a/include/sacn/cpp/dmx_merger.h
+++ b/include/sacn/cpp/dmx_merger.h
@@ -40,13 +40,13 @@ namespace sacn
 /**
  * @ingroup sacn_dmx_merger_cpp
  * @brief An instance of sACN DMX Merger functionality; see @ref using_dmx_merger.
- * 
+ *
  * This class instantiates software mergers for buffers containing DMX512-A start code 0 packets.
  * It also uses buffers containing DMX512-A start code 0xdd packets to support per-address priority.
- * 
+ *
  * While this class is used to easily merge the outputs from the sACN Receiver API, it can also be used
  * to merge your own DMX sources together, even in combination with the sources received via sACN.
- * 
+ *
  * When asked to calculate the merge, the merger will evaluate the current source
  * buffers and update two result buffers:
  *  - 512 bytes for the merged data values (i.e. "winning level").  These are calculated by using
@@ -87,8 +87,8 @@ public:
     uint8_t* per_address_priorities{nullptr};
 
     /** Buffer of #DMX_ADDRESS_COUNT source IDs that indicate the current winner of the merge for that slot, or
-        #SACN_DMX_MERGER_SOURCE_INVALID to indicate that no source is providing values for that slot. This is used if you
-        need to know the source of each slot. If you only need to know whether or not a slot is sourced, set this to
+        #SACN_DMX_MERGER_SOURCE_INVALID to indicate that no source is providing values for that slot. This is used if
+       you need to know the source of each slot. If you only need to know whether or not a slot is sourced, set this to
         NULL and use per_address_priorities (which has half the memory footprint) to check if the slot has a priority of
         0 (not sourced).
         Memory is owned by the application.*/
@@ -107,8 +107,8 @@ public:
   DmxMerger() = default;
   DmxMerger(const DmxMerger& other) = delete;
   DmxMerger& operator=(const DmxMerger& other) = delete;
-  DmxMerger(DmxMerger&& other) = default;             /**< Move a dmx merger instance. */
-  DmxMerger& operator=(DmxMerger&& other) = default;  /**< Move a dmx merger instance. */
+  DmxMerger(DmxMerger&& other) = default;            /**< Move a dmx merger instance. */
+  DmxMerger& operator=(DmxMerger&& other) = default; /**< Move a dmx merger instance. */
 
   etcpal::Error Startup(const Settings& settings);
   void Shutdown();

--- a/include/sacn/cpp/merge_receiver.h
+++ b/include/sacn/cpp/merge_receiver.h
@@ -80,11 +80,11 @@ public:
      *
      * @param[in] handle The merge receiver's handle.
      * @param[in] universe The universe this merge receiver is monitoring.
-     * @param[in] slots Buffer of #SACN_DMX_ADDRESS_COUNT bytes containing the merged levels for the universe.  This buffer
+     * @param[in] slots Buffer of #DMX_ADDRESS_COUNT bytes containing the merged levels for the universe.  This buffer
      *                  is owned by the library.
      * @param[in] slot_owners Buffer of #DMX_ADDRESS_COUNT source_ids.  If a value in the buffer is
-     *           #DMX_MERGER_SOURCE_INVALID, the corresponding slot is not currently controlled. You can also use
-     *            SACN_DMX_MERGER_SOURCE_IS_VALID(slot_owners, index) to check the slot validity. This buffer is owned
+     *           #SACN_DMX_MERGER_SOURCE_INVALID, the corresponding slot is not currently controlled. You can also use
+     *           #SACN_DMX_MERGER_SOURCE_IS_VALID(slot_owners, index) to check the slot validity. This buffer is owned
      *            by the library.
      */
     virtual void HandleMergedData(Handle handle, uint16_t universe, const uint8_t* slots,

--- a/include/sacn/cpp/merge_receiver.h
+++ b/include/sacn/cpp/merge_receiver.h
@@ -157,8 +157,8 @@ public:
   MergeReceiver() = default;
   MergeReceiver(const MergeReceiver& other) = delete;
   MergeReceiver& operator=(const MergeReceiver& other) = delete;
-  MergeReceiver(MergeReceiver&& other) = default;             /**< Move a merge receiver instance. */
-  MergeReceiver& operator=(MergeReceiver&& other) = default;  /**< Move a merge receiver instance. */
+  MergeReceiver(MergeReceiver&& other) = default;            /**< Move a merge receiver instance. */
+  MergeReceiver& operator=(MergeReceiver&& other) = default; /**< Move a merge receiver instance. */
 
   etcpal::Error Startup(const Settings& settings, NotifyHandler& notify_handler);
   etcpal::Error Startup(const Settings& settings, NotifyHandler& notify_handler,
@@ -195,8 +195,9 @@ extern "C" inline void MergeReceiverCbMergedData(sacn_merge_receiver_t handle, u
   }
 }
 
-extern "C" inline void MergeReceiverCbNonDmx(sacn_merge_receiver_t handle, uint16_t universe, const EtcPalSockAddr* source_addr,
-                                             const SacnHeaderData* header, const uint8_t* pdata, void* context)
+extern "C" inline void MergeReceiverCbNonDmx(sacn_merge_receiver_t handle, uint16_t universe,
+                                             const EtcPalSockAddr* source_addr, const SacnHeaderData* header,
+                                             const uint8_t* pdata, void* context)
 {
   if (context && source_addr && header)
   {
@@ -205,7 +206,8 @@ extern "C" inline void MergeReceiverCbNonDmx(sacn_merge_receiver_t handle, uint1
   }
 }
 
-extern "C" inline void MergeReceiverCbSourceLimitExceeded(sacn_merge_receiver_t handle, uint16_t universe, void* context)
+extern "C" inline void MergeReceiverCbSourceLimitExceeded(sacn_merge_receiver_t handle, uint16_t universe,
+                                                          void* context)
 {
   if (context)
   {
@@ -238,7 +240,7 @@ inline bool MergeReceiver::Settings::IsValid() const
  * @brief Start listening for sACN data on a universe.
  *
  * This is the overload of Startup that uses all network interfaces.
- * 
+ *
  * An sACN merge receiver can listen on one universe at a time, and each universe can only be listened to
  * by one merge receiver at at time.
  *
@@ -274,7 +276,8 @@ inline etcpal::Error MergeReceiver::Startup(const Settings& settings, NotifyHand
  * @param[in] settings Configuration parameters for the sACN merge receiver and this class instance.
  * @param[in] notify_handler The notification interface to call back to the application.
  * @param[in, out] netints Optional. If !empty, this is the list of interfaces the application wants to use, and the
- * operation_succeeded flags are filled in.  If empty, all available interfaces are tried and this vector isn't modified.
+ * operation_succeeded flags are filled in.  If empty, all available interfaces are tried and this vector isn't
+ * modified.
  * @return #kEtcPalErrOk: Merge Receiver created successfully.
  * @return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.
  * @return #kEtcPalErrInvalid: Invalid parameter provided.
@@ -289,9 +292,9 @@ inline etcpal::Error MergeReceiver::Startup(const Settings& settings, NotifyHand
 {
   SacnMergeReceiverConfig config = TranslateConfig(settings, notify_handler);
 
-  if(netints.empty())
+  if (netints.empty())
     return sacn_merge_receiver_create(&config, &handle_, NULL, 0);
-  
+
   return sacn_merge_receiver_create(&config, &handle_, netints.data(), netints.size());
 }
 
@@ -349,9 +352,9 @@ inline etcpal::Error MergeReceiver::ChangeUniverse(uint16_t new_universe_id)
  *
  * This is typically used when the application detects that the list of networking interfaces has changed.
  *
- * After this call completes successfully, the merge receiver is in a sampling period for the new universe and will provide
- * HandleSourcesFound() calls when appropriate.
- * If this call fails, the caller must call Shutdown() on this class, because it may be in an invalid state.
+ * After this call completes successfully, the merge receiver is in a sampling period for the new universe and will
+ * provide HandleSourcesFound() calls when appropriate. If this call fails, the caller must call Shutdown() on this
+ * class, because it may be in an invalid state.
  *
  * Note that the networking reset is considered successful if it is able to successfully use any of the
  * network interfaces.  This will only return #kEtcPalErrNoNetints if none of the interfaces work.
@@ -382,7 +385,8 @@ inline etcpal::Error MergeReceiver::ResetNetworking()
  * network interfaces passed in.  This will only return #kEtcPalErrNoNetints if none of the interfaces work.
  *
  * @param[in, out] netints Optional. If !empty, this is the list of interfaces the application wants to use, and the
- * operation_succeeded flags are filled in.  If empty, all available interfaces are tried and this vector isn't modified.
+ * operation_succeeded flags are filled in.  If empty, all available interfaces are tried and this vector isn't
+ * modified.
  * @return #kEtcPalErrOk: Universe changed successfully.
  * @return #kEtcPalErrNoNetints: None of the network interfaces provided were usable by the library.
  * @return #kEtcPalErrInvalid: Invalid parameter provided.

--- a/include/sacn/cpp/merge_receiver.h
+++ b/include/sacn/cpp/merge_receiver.h
@@ -80,7 +80,7 @@ public:
      *
      * @param[in] handle The merge receiver's handle.
      * @param[in] universe The universe this merge receiver is monitoring.
-     * @param[in] slots Buffer of #DMX_ADDRESS_COUNT bytes containing the merged levels for the universe.  This buffer
+     * @param[in] slots Buffer of #SACN_DMX_ADDRESS_COUNT bytes containing the merged levels for the universe.  This buffer
      *                  is owned by the library.
      * @param[in] slot_owners Buffer of #DMX_ADDRESS_COUNT source_ids.  If a value in the buffer is
      *           #DMX_MERGER_SOURCE_INVALID, the corresponding slot is not currently controlled. You can also use
@@ -143,7 +143,7 @@ public:
 
     /** If true, this allows per-address priorities (if any are received) to be fed into the merger. If false, received
         per-address priorities are ignored, and only universe priorities are used in the merger. Keep in mind that this
-        setting will be ignored if #SACN_ETC_PRIORITY_EXTENSTION = 0, in which case per-address priorities are ignored.
+        setting will be ignored if #SACN_ETC_PRIORITY_EXTENSION = 0, in which case per-address priorities are ignored.
      */
     bool use_pap{true};
 

--- a/include/sacn/cpp/source.h
+++ b/include/sacn/cpp/source.h
@@ -325,7 +325,7 @@ inline etcpal::Error Source::ChangeName(const std::string& new_name)
  * If the source is not marked as unicast_only, the source will add the universe to its sACN Universe
  * Discovery packets.
 
- * @param[in] config Configuration parameters for the universe to be added.
+ * @param[in] settings Configuration parameters for the universe to be added.
  * @return #kEtcPalErrOk: Universe successfully added.
  * @return #kEtcPalErrInvalid: Invalid parameter provided.
  * @return #kEtcPalErrNotInit: Module not initialized.
@@ -417,6 +417,7 @@ inline etcpal::Error Source::ChangePriority(uint16_t universe, uint8_t new_prior
  * E1.31) "intended for use in visualization or media server preview applications and shall not be
  * used to generate live output."
  *
+ * @param[in] universe The universe to change.
  * @param[in] new_preview_flag The new send_preview option.
  * @return #kEtcPalErrOk: send_preview option set successfully.
  * @return #kEtcPalErrInvalid: Invalid parameter provided.

--- a/include/sacn/dmx_merger.h
+++ b/include/sacn/dmx_merger.h
@@ -75,7 +75,7 @@ typedef int sacn_dmx_merger_t;
 typedef uint16_t sacn_source_id_t;
 
 /** An invalid source id handle value. */
-#define SACN_DMX_MERGER_SOURCE_INVALID ((sacn_source_id_t) -1)
+#define SACN_DMX_MERGER_SOURCE_INVALID ((sacn_source_id_t)-1)
 
 /** A set of configuration information for a merger instance. */
 typedef struct SacnDmxMergerConfig
@@ -96,9 +96,9 @@ typedef struct SacnDmxMergerConfig
   uint8_t* per_address_priorities;
 
   /** Buffer of #DMX_ADDRESS_COUNT source IDs that indicate the current winner of the merge for that slot, or
-      #SACN_DMX_MERGER_SOURCE_INVALID to indicate that no source is providing values for that slot. This is used if you need
-      to know the source of each slot. If you only need to know whether or not a slot is sourced, set this to NULL and
-      use per_address_priorities (which has half the memory footprint) to check if the slot has a priority of 0 (not
+      #SACN_DMX_MERGER_SOURCE_INVALID to indicate that no source is providing values for that slot. This is used if you
+     need to know the source of each slot. If you only need to know whether or not a slot is sourced, set this to NULL
+     and use per_address_priorities (which has half the memory footprint) to check if the slot has a priority of 0 (not
       sourced).
       Memory is owned by the application.*/
   sacn_source_id_t* slot_owners;

--- a/include/sacn/dmx_merger.h
+++ b/include/sacn/dmx_merger.h
@@ -96,7 +96,7 @@ typedef struct SacnDmxMergerConfig
   uint8_t* per_address_priorities;
 
   /** Buffer of #DMX_ADDRESS_COUNT source IDs that indicate the current winner of the merge for that slot, or
-      #DMX_MERGER_SOURCE_INVALID to indicate that no source is providing values for that slot. This is used if you need
+      #SACN_DMX_MERGER_SOURCE_INVALID to indicate that no source is providing values for that slot. This is used if you need
       to know the source of each slot. If you only need to know whether or not a slot is sourced, set this to NULL and
       use per_address_priorities (which has half the memory footprint) to check if the slot has a priority of 0 (not
       sourced).

--- a/include/sacn/merge_receiver.h
+++ b/include/sacn/merge_receiver.h
@@ -74,7 +74,7 @@ typedef int sacn_merge_receiver_t;
  * @param[in] slots Buffer of #DMX_ADDRESS_COUNT bytes containing the merged levels for the universe. This buffer is
  * owned by the library.
  * @param[in] slot_owners Buffer of #DMX_ADDRESS_COUNT source_ids.  If a value in the buffer is
- *           #DMX_MERGER_SOURCE_INVALID, the corresponding slot is not currently controlled. You can also use
+ *           #SACN_DMX_MERGER_SOURCE_INVALID, the corresponding slot is not currently controlled. You can also use
  *            SACN_DMX_MERGER_SOURCE_IS_VALID(slot_owners, index) to check the slot validity. This buffer is owned by
  * the library.
  * @param[in] context Context pointer that was given at the creation of the merge receiver instance.
@@ -149,7 +149,7 @@ typedef struct SacnMergeReceiverConfig
 
   /** If true, this allows per-address priorities (if any are received) to be fed into the merger. If false, received
       per-address priorities are ignored, and only universe priorities are used in the merger. Keep in mind that this
-      setting will be ignored if #SACN_ETC_PRIORITY_EXTENSTION = 0, in which case per-address priorities are ignored. */
+      setting will be ignored if #SACN_ETC_PRIORITY_EXTENSION = 0, in which case per-address priorities are ignored. */
   bool use_pap;
 } SacnMergeReceiverConfig;
 

--- a/include/sacn/merge_receiver.h
+++ b/include/sacn/merge_receiver.h
@@ -75,7 +75,7 @@ typedef int sacn_merge_receiver_t;
  * owned by the library.
  * @param[in] slot_owners Buffer of #DMX_ADDRESS_COUNT source_ids.  If a value in the buffer is
  *           #SACN_DMX_MERGER_SOURCE_INVALID, the corresponding slot is not currently controlled. You can also use
- *            SACN_DMX_MERGER_SOURCE_IS_VALID(slot_owners, index) to check the slot validity. This buffer is owned by
+ *           #SACN_DMX_MERGER_SOURCE_IS_VALID(slot_owners, index) to check the slot validity. This buffer is owned by
  * the library.
  * @param[in] context Context pointer that was given at the creation of the merge receiver instance.
  */

--- a/include/sacn/receiver.h
+++ b/include/sacn/receiver.h
@@ -199,7 +199,7 @@ typedef void (*SacnSourcePapLostCallback)(sacn_receiver_t handle, uint16_t unive
  * platforms), and the configuration you pass to sacn_receiver_create() has source_count_max set to
  * #SACN_RECEIVER_INFINITE_SOURCES, this callback will never be called and may be set to NULL.
 
- * if #SACNDYNAMIC_MEM was defined to 0 when sACN was compiled, source_count_max is ignored and
+ * if #SACN_DYNAMIC_MEM was defined to 0 when sACN was compiled, source_count_max is ignored and
  * #SACN_RECEIVER_MAX_SOURCES_PER_UNIVERSE is used instead.
  *
  * This callback is rate-limited: it will only be called when the first sACN packet is received

--- a/include/sacn/receiver.h
+++ b/include/sacn/receiver.h
@@ -257,8 +257,7 @@ etcpal_error_t sacn_receiver_create(const SacnReceiverConfig* config, sacn_recei
 etcpal_error_t sacn_receiver_destroy(sacn_receiver_t handle);
 etcpal_error_t sacn_receiver_get_universe(sacn_receiver_t handle, uint16_t* universe_id);
 etcpal_error_t sacn_receiver_change_universe(sacn_receiver_t handle, uint16_t new_universe_id);
-etcpal_error_t sacn_receiver_reset_networking(sacn_receiver_t handle, SacnMcastInterface* netints,
-                                              size_t num_netints);
+etcpal_error_t sacn_receiver_reset_networking(sacn_receiver_t handle, SacnMcastInterface* netints, size_t num_netints);
 
 void sacn_receiver_set_standard_version(sacn_standard_version_t version);
 sacn_standard_version_t sacn_receiver_get_standard_version();

--- a/include/sacn/source.h
+++ b/include/sacn/source.h
@@ -96,6 +96,7 @@ typedef struct SacnSourceConfig
 
 void sacn_source_config_init(SacnSourceConfig* config);
 
+/** A set of configuration information for a sACN universe. */
 typedef struct SacnSourceUniverseConfig
 {
   /********* Required values **********/

--- a/include/sacn/source.h
+++ b/include/sacn/source.h
@@ -42,7 +42,7 @@
  * @brief The sACN Source API; see @ref using_source.
  *
  * Components that send sACN are referred to as sACN Sources. Use this API to act as an sACN Source.
- * 
+ *
  * See @ref using_source for a detailed description of how to use this API.
  *
  * @{
@@ -113,7 +113,8 @@ typedef struct SacnSourceUniverseConfig
 
   /********* Optional values **********/
 
-  /** The sACN universe priority that is sent in each packet. This is only allowed to be from 0 - 200. Defaults to 100. */
+  /** The sACN universe priority that is sent in each packet. This is only allowed to be from 0 - 200. Defaults to 100.
+   */
   uint8_t priority;
   /** The (optional) buffer of up to 512 per-address priorities that will be sent each tick.
       If this is NULL, only the universe priority will be used.
@@ -122,7 +123,7 @@ typedef struct SacnSourceUniverseConfig
       specification.
       The memory is owned by the application, and should not be destroyed until after the universe is
       deleted on this source. The size of this buffer must match the size of values_buffer.  */
-  const uint8_t* priorities_buffer; 
+  const uint8_t* priorities_buffer;
 
   /** If true, this sACN source will send preview data. Defaults to false. */
   bool send_preview;
@@ -149,8 +150,8 @@ typedef struct SacnSourceUniverseConfig
 
 void sacn_source_universe_config_init(SacnSourceUniverseConfig* config);
 
-etcpal_error_t sacn_source_create(const SacnSourceConfig* config, sacn_source_t* handle,
-                                  SacnMcastInterface* netints, size_t num_netints);
+etcpal_error_t sacn_source_create(const SacnSourceConfig* config, sacn_source_t* handle, SacnMcastInterface* netints,
+                                  size_t num_netints);
 void sacn_source_destroy(sacn_source_t handle);
 
 etcpal_error_t sacn_source_change_name(sacn_source_t handle, const char* new_name);

--- a/src/sacn/source.c
+++ b/src/sacn/source.c
@@ -89,8 +89,8 @@ void sacn_source_universe_config_init(SacnSourceUniverseConfig* config)
  * @return #kEtcPalErrNotFound: A network interface ID given was not found on the system.
  * @return #kEtcPalErrSys: An internal library or system call error occurred.
  */
-etcpal_error_t sacn_source_create(const SacnSourceConfig* config, sacn_source_t* handle,
-                                  SacnMcastInterface* netints, size_t num_netints)
+etcpal_error_t sacn_source_create(const SacnSourceConfig* config, sacn_source_t* handle, SacnMcastInterface* netints,
+                                  size_t num_netints)
 {
   // If the Tick thread hasn't been started yet, start it if the config isn't manual.
 

--- a/src/sacn/source.c
+++ b/src/sacn/source.c
@@ -258,6 +258,7 @@ etcpal_error_t sacn_source_change_priority(sacn_source_t handle, uint16_t univer
  * used to generate live output."
  *
  * @param[in] handle Handle to the source for which to set the Preview_Data option.
+ * @param[in] universe The universe to change.
  * @param[in] new_preview_flag The new send_preview option.
  * @return #kEtcPalErrOk: send_preview option set successfully.
  * @return #kEtcPalErrInvalid: Invalid parameter provided.
@@ -385,7 +386,7 @@ void sacn_source_set_list_dirty(sacn_source_t handle, const uint16_t* universes,
   ETCPAL_UNUSED_ARG(num_universes);
 }
 
-/*@
+/**
  * @brief Like sacn_source_set_dirty, but also sets the force_sync flag on the packet.
  *
  * This function indicates that the data in the buffer for this source and universe has changed,


### PR DESCRIPTION
I noticed there were doxygen warnings in the last PR, so I created this one to fix them.  I also reformatted the touched files, so you might want to look at the commits.