### PR TITLE
Sources Found Replacement

### DIFF
--- a/examples/receiver/src/main.c
+++ b/examples/receiver/src/main.c
@@ -516,8 +516,8 @@ static void handle_source_limit_exceeded(sacn_receiver_t handle, uint16_t univer
 static const SacnReceiverCallbacks kSacnCallbacks = {
   handle_universe_data,
   handle_sources_lost,
-  handle_sampling_period_ended,
   handle_sampling_period_started,
+  handle_sampling_period_ended,
   handle_source_pap_lost,
   handle_source_limit_exceeded,
   NULL

--- a/include/sacn/source.h
+++ b/include/sacn/source.h
@@ -42,7 +42,7 @@
  * @brief The sACN Source API; see @ref using_source.
  *
  * Components that send sACN are referred to as sACN Sources. Use this API to act as an sACN Source.
- *
+ * 
  * See @ref using_source for a detailed description of how to use this API.
  *
  * @{

--- a/include/sacn/source.h
+++ b/include/sacn/source.h
@@ -42,7 +42,7 @@
  * @brief The sACN Source API; see @ref using_source.
  *
  * Components that send sACN are referred to as sACN Sources. Use this API to act as an sACN Source.
- * 
+ *
  * See @ref using_source for a detailed description of how to use this API.
  *
  * @{

--- a/src/sacn/mem.c
+++ b/src/sacn/mem.c
@@ -82,6 +82,16 @@ typedef struct SourcesLostNotificationBuf
   SACN_DECLARE_BUF(SourcesLostNotification, buf, SACN_RECEIVER_MAX_UNIVERSES);
 } SourcesLostNotificationBuf;
 
+typedef struct SamplingStartedNotificationBuf
+{
+  SACN_DECLARE_BUF(SamplingStartedNotification, buf, SACN_RECEIVER_MAX_UNIVERSES);
+} SamplingStartedNotificationBuf;
+
+typedef struct SamplingEndedNotificationBuf
+{
+  SACN_DECLARE_BUF(SamplingEndedNotification, buf, SACN_RECEIVER_MAX_UNIVERSES);
+} SamplingEndedNotificationBuf;
+
 typedef struct ToEraseBuf
 {
   SACN_DECLARE_BUF(SacnTrackedSource*, buf, SACN_RECEIVER_MAX_SOURCES_PER_UNIVERSE);
@@ -101,6 +111,8 @@ static struct SacnMemBufs
   UniverseDataNotification* universe_data;
   SourcesLostNotificationBuf* sources_lost;
   SourcePapLostNotification* source_pap_lost;
+  SamplingStartedNotificationBuf* sampling_started;
+  SamplingEndedNotificationBuf* sampling_ended;
   SourceLimitExceededNotification* source_limit_exceeded;
 #else
   SacnSourceStatusLists status_lists[SACN_RECEIVER_MAX_THREADS];
@@ -110,6 +122,8 @@ static struct SacnMemBufs
   UniverseDataNotification universe_data[SACN_RECEIVER_MAX_THREADS];
   SourcesLostNotificationBuf sources_lost[SACN_RECEIVER_MAX_THREADS];
   SourcePapLostNotification source_pap_lost[SACN_RECEIVER_MAX_THREADS];
+  SamplingStartedNotificationBuf sampling_started[SACN_RECEIVER_MAX_THREADS];
+  SamplingEndedNotificationBuf sampling_ended[SACN_RECEIVER_MAX_THREADS];
   SourceLimitExceededNotification source_limit_exceeded[SACN_RECEIVER_MAX_THREADS];
 #endif
 } mem_bufs;
@@ -142,6 +156,11 @@ static etcpal_error_t init_sources_lost_array(SourcesLostNotification* sources_l
 
 static etcpal_error_t init_source_pap_lost_buf(unsigned int num_threads);
 
+static etcpal_error_t init_sampling_started_bufs(unsigned int num_threads);
+static etcpal_error_t init_sampling_started_buf(SamplingStartedNotificationBuf* sampling_started_buf);
+static etcpal_error_t init_sampling_ended_bufs(unsigned int num_threads);
+static etcpal_error_t init_sampling_ended_buf(SamplingEndedNotificationBuf* sampling_ended_buf);
+
 static etcpal_error_t init_source_limit_exceeded_buf(unsigned int num_threads);
 
 // Dynamic memory deinitialization
@@ -161,6 +180,11 @@ static void deinit_sources_lost_buf(SourcesLostNotificationBuf* sources_lost_buf
 static void deinit_sources_lost_entry(SourcesLostNotification* sources_lost);
 
 static void deinit_source_pap_lost_buf(void);
+
+static void deinit_sampling_started_bufs(void);
+static void deinit_sampling_started_buf(SamplingStartedNotificationBuf* sampling_started_buf);
+static void deinit_sampling_ended_bufs(void);
+static void deinit_sampling_ended_buf(SamplingEndedNotificationBuf* sampling_ended_buf);
 
 static void deinit_source_limit_exceeded_buf(void);
 #endif  // SACN_DYNAMIC_MEM
@@ -193,6 +217,10 @@ etcpal_error_t sacn_mem_init(unsigned int num_threads)
   if (res == kEtcPalErrOk)
     res = init_source_pap_lost_buf(num_threads);
   if (res == kEtcPalErrOk)
+    res = init_sampling_started_bufs(num_threads);
+  if (res == kEtcPalErrOk)
+    res = init_sampling_ended_bufs(num_threads);
+  if (res == kEtcPalErrOk)
     res = init_source_limit_exceeded_buf(num_threads);
 #endif
 
@@ -210,6 +238,8 @@ void sacn_mem_deinit(void)
 {
 #if SACN_DYNAMIC_MEM
   deinit_source_limit_exceeded_buf();
+  deinit_sampling_ended_bufs();
+  deinit_sampling_started_bufs();
   deinit_source_pap_lost_buf();
   deinit_sources_lost_bufs();
   deinit_universe_data_buf();
@@ -375,6 +405,58 @@ SourcesLostNotification* get_sources_lost_buffer(sacn_thread_id_t thread_id, siz
 #endif
 
     zero_sources_lost_array(notifications->buf, size);
+    return notifications->buf;
+  }
+  return NULL;
+}
+
+/*
+ * Get a buffer of SamplingStartedNotification instances associated with a given thread. All
+ * instances in the array will be initialized to default values.
+ *
+ * [in] thread_id Thread ID for which to get the buffer.
+ * [in] size Size of the buffer requested.
+ * Returns the buffer or NULL if the thread ID was invalid or memory could not be
+ * allocated.
+ */
+SamplingStartedNotification* get_sampling_started_buffer(sacn_thread_id_t thread_id, size_t size)
+{
+  if (thread_id < mem_bufs.num_threads)
+  {
+    SamplingStartedNotificationBuf* notifications = &mem_bufs.sampling_started[thread_id];
+
+    CHECK_CAPACITY(notifications, size, buf, SamplingStartedNotification, SACN_RECEIVER_MAX_UNIVERSES, NULL);
+
+    memset(notifications->buf, 0, size * sizeof(SamplingStartedNotification));
+    for (size_t i = 0; i < size; ++i)
+      notifications->buf[i].handle = SACN_RECEIVER_INVALID;
+
+    return notifications->buf;
+  }
+  return NULL;
+}
+
+/*
+ * Get a buffer of SamplingEndedNotification instances associated with a given thread. All
+ * instances in the array will be initialized to default values.
+ *
+ * [in] thread_id Thread ID for which to get the buffer.
+ * [in] size Size of the buffer requested.
+ * Returns the buffer or NULL if the thread ID was invalid or memory could not be
+ * allocated.
+ */
+SamplingEndedNotification* get_sampling_ended_buffer(sacn_thread_id_t thread_id, size_t size)
+{
+  if (thread_id < mem_bufs.num_threads)
+  {
+    SamplingEndedNotificationBuf* notifications = &mem_bufs.sampling_ended[thread_id];
+
+    CHECK_CAPACITY(notifications, size, buf, SamplingEndedNotification, SACN_RECEIVER_MAX_UNIVERSES, NULL);
+
+    memset(notifications->buf, 0, size * sizeof(SamplingEndedNotification));
+    for (size_t i = 0; i < size; ++i)
+      notifications->buf[i].handle = SACN_RECEIVER_INVALID;
+
     return notifications->buf;
   }
   return NULL;
@@ -777,6 +859,60 @@ etcpal_error_t init_sources_lost_array(SourcesLostNotification* sources_lost_arr
   return kEtcPalErrOk;
 }
 
+etcpal_error_t init_sampling_started_bufs(unsigned int num_threads)
+{
+  mem_bufs.sampling_started = calloc(num_threads, sizeof(SamplingStartedNotificationBuf));
+  if (!mem_bufs.sampling_started)
+    return kEtcPalErrNoMem;
+
+  for (unsigned int i = 0; i < num_threads; ++i)
+  {
+    etcpal_error_t res = init_sampling_started_buf(&mem_bufs.sampling_started[i]);
+    if (res != kEtcPalErrOk)
+      return res;
+  }
+  return kEtcPalErrOk;
+}
+
+etcpal_error_t init_sampling_started_buf(SamplingStartedNotificationBuf* sampling_started_buf)
+{
+  SACN_ASSERT(sampling_started_buf);
+
+  sampling_started_buf->buf = calloc(INITIAL_CAPACITY, sizeof(SamplingStartedNotification));
+  if (!sampling_started_buf->buf)
+    return kEtcPalErrNoMem;
+
+  sampling_started_buf->buf_capacity = INITIAL_CAPACITY;
+  return kEtcPalErrOk;
+}
+
+etcpal_error_t init_sampling_ended_bufs(unsigned int num_threads)
+{
+  mem_bufs.sampling_ended = calloc(num_threads, sizeof(SamplingEndedNotificationBuf));
+  if (!mem_bufs.sampling_ended)
+    return kEtcPalErrNoMem;
+
+  for (unsigned int i = 0; i < num_threads; ++i)
+  {
+    etcpal_error_t res = init_sampling_ended_buf(&mem_bufs.sampling_ended[i]);
+    if (res != kEtcPalErrOk)
+      return res;
+  }
+  return kEtcPalErrOk;
+}
+
+etcpal_error_t init_sampling_ended_buf(SamplingEndedNotificationBuf* sampling_ended_buf)
+{
+  SACN_ASSERT(sampling_ended_buf);
+
+  sampling_ended_buf->buf = calloc(INITIAL_CAPACITY, sizeof(SamplingEndedNotification));
+  if (!sampling_ended_buf->buf)
+    return kEtcPalErrNoMem;
+
+  sampling_ended_buf->buf_capacity = INITIAL_CAPACITY;
+  return kEtcPalErrOk;
+}
+
 
 etcpal_error_t init_source_pap_lost_buf(unsigned int num_threads)
 {
@@ -901,6 +1037,42 @@ void deinit_source_pap_lost_buf(void)
 {
   if (mem_bufs.source_pap_lost)
     free(mem_bufs.source_pap_lost);
+}
+
+void deinit_sampling_started_bufs(void)
+{
+  if (mem_bufs.sampling_started)
+  {
+    for (unsigned int i = 0; i < mem_bufs.num_threads; ++i)
+      deinit_sampling_started_buf(&mem_bufs.sampling_started[i]);
+    free(mem_bufs.sampling_started);
+  }
+}
+
+void deinit_sampling_started_buf(SamplingStartedNotificationBuf* sampling_started_buf)
+{
+  SACN_ASSERT(sampling_started_buf);
+
+  if (sampling_started_buf->buf)
+    free(sampling_started_buf->buf);
+}
+
+void deinit_sampling_ended_bufs(void)
+{
+  if (mem_bufs.sampling_ended)
+  {
+    for (unsigned int i = 0; i < mem_bufs.num_threads; ++i)
+      deinit_sampling_ended_buf(&mem_bufs.sampling_ended[i]);
+    free(mem_bufs.sampling_ended);
+  }
+}
+
+void deinit_sampling_ended_buf(SamplingEndedNotificationBuf* sampling_ended_buf)
+{
+  SACN_ASSERT(sampling_ended_buf);
+
+  if (sampling_ended_buf->buf)
+    free(sampling_ended_buf->buf);
 }
 
 void deinit_source_limit_exceeded_buf(void)

--- a/src/sacn/private/common.h
+++ b/src/sacn/private/common.h
@@ -188,6 +188,7 @@ struct SacnReceiver
 
   // State tracking
   bool sampling;
+  bool notified_sampling_started;
   EtcPalTimer sample_timer;
   bool suppress_limit_exceeded_notification;
   EtcPalRbTree sources;       // The sources being tracked on this universe.
@@ -227,26 +228,6 @@ typedef enum
   kRecvStateHaveDmxAndPap
 } sacn_recv_state_t;
 #endif
-
-typedef struct SourceDataBuffer
-{
-  /* Whether this buffer has been written to yet. */
-  bool written;
-  /* The address from which we received this data. */
-  EtcPalSockAddr from_addr;
-  /* The priority of the sACN data. Valid range is 0-200, inclusive. */
-  uint8_t priority;
-  /* Whether the Preview_Data bit is set for the sACN data. From E1.31: "Indicates that the data in
-   * this packet is intended for use in visualization or media server preview applications and
-   * shall not be used to generate live output." */
-  bool preview;
-  /* The start code of the DMX data. */
-  uint8_t start_code;
-  /* The number of slots in the DMX data. */
-  uint16_t slot_count;
-  /* The DMX data. */
-  uint8_t data[DMX_ADDRESS_COUNT];
-} SourceDataBuffer;
 
 /* An sACN source that is being tracked on a given universe. */
 typedef struct SacnTrackedSource
@@ -290,6 +271,24 @@ typedef struct SourcesLostNotification
   size_t num_lost_sources;
   void* context;
 } SourcesLostNotification;
+
+/* Data for the sampling_period_started() callback */
+typedef struct SamplingStartedNotification
+{
+  SacnSamplingPeriodStartedCallback callback;
+  sacn_receiver_t handle;
+  uint16_t universe;
+  void* context;
+} SamplingStartedNotification;
+
+/* Data for the sampling_period_ended() callback */
+typedef struct SamplingEndedNotification
+{
+  SacnSamplingPeriodEndedCallback callback;
+  sacn_receiver_t handle;
+  uint16_t universe;
+  void* context;
+} SamplingEndedNotification;
 
 /* Data for the source_pap_lost() callback */
 typedef struct SourcePapLostNotification

--- a/src/sacn/private/mem.h
+++ b/src/sacn/private/mem.h
@@ -51,6 +51,8 @@ SourceLimitExceededNotification* get_source_limit_exceeded(sacn_thread_id_t thre
 
 // These are processed in the periodic timeout processing, so there are multiple per thread.
 SourcesLostNotification* get_sources_lost_buffer(sacn_thread_id_t thread_id, size_t size);
+SamplingStartedNotification* get_sampling_started_buffer(sacn_thread_id_t thread_id, size_t size);
+SamplingEndedNotification* get_sampling_ended_buffer(sacn_thread_id_t thread_id, size_t size);
 
 bool add_offline_source(SacnSourceStatusLists* status_lists, const EtcPalUuid* cid, const char* name, bool terminated);
 bool add_online_source(SacnSourceStatusLists* status_lists, const EtcPalUuid* cid, const char* name);


### PR DESCRIPTION
Replaces the sources found notification with sampling period begin/end. Restores logic that calls universe data during the sampling period.