### PR TITLE
Set WARN_AS_ERROR

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -762,7 +762,7 @@ WARN_NO_PARAMDOC       = NO
 # a warning is encountered.
 # The default value is: NO.
 
-WARN_AS_ERROR          = NO
+WARN_AS_ERROR          = FAIL_ON_WARNINGS
 
 # The WARN_FORMAT tag determines the format of the warning messages that doxygen
 # can produce. The string should contain the $file, $line, and $text tags, which

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -762,7 +762,7 @@ WARN_NO_PARAMDOC       = NO
 # a warning is encountered.
 # The default value is: NO.
 
-WARN_AS_ERROR          = FAIL_ON_WARNINGS
+WARN_AS_ERROR          = YES
 
 # The WARN_FORMAT tag determines the format of the warning messages that doxygen
 # can produce. The string should contain the $file, $line, and $text tags, which

--- a/include/sacn/common.h
+++ b/include/sacn/common.h
@@ -59,8 +59,11 @@ extern "C" {
  */
 typedef enum 
 {
+  /** Use IPv4 only. */
   kSacnIpV4Only,
+  /** Use IPv6 only. */
   kSacnIpV6Only,
+  /** Use both IPv4 and IPv6. */
   kSacnIpV4AndIpV6
 } sacn_ip_support_t;
 


### PR DESCRIPTION
This PR aims to set the WARN_AS_ERROR flag in the Doxyfile to a suitable value, as well as to fix any warnings/errors that pop up.