### PR TITLE
sACN Receiver: Implement ip_supported Setting

### DIFF
--- a/src/sacn/private/common.h
+++ b/src/sacn/private/common.h
@@ -205,6 +205,9 @@ struct SacnReceiver
    * instead. */
   size_t source_count_max;
 
+  /* What IP networking the receiver will support. */
+  sacn_ip_support_t ip_supported;
+
   SacnReceiver* next;
 };
 

--- a/src/sacn/private/sockets.h
+++ b/src/sacn/private/sockets.h
@@ -45,7 +45,7 @@ etcpal_error_t sacn_validate_netint_config(SacnMcastInterface* netints, size_t n
 
 etcpal_error_t sacn_add_receiver_socket(sacn_thread_id_t thread_id, etcpal_iptype_t ip_type, uint16_t universe,
                                         const EtcPalMcastNetintId* netints, size_t num_netints, etcpal_socket_t* socket);
-void sacn_remove_receiver_socket(sacn_thread_id_t thread_id, etcpal_socket_t socket, bool close_now);
+void sacn_remove_receiver_socket(sacn_thread_id_t thread_id, etcpal_socket_t *socket, bool close_now);
 
 // Functions to be called from the receive thread
 void sacn_add_pending_sockets(SacnRecvThreadContext* recv_thread_context);

--- a/src/sacn/sockets.c
+++ b/src/sacn/sockets.c
@@ -321,14 +321,17 @@ etcpal_error_t sacn_add_receiver_socket(sacn_thread_id_t thread_id, etcpal_iptyp
   return res;
 }
 
-void sacn_remove_receiver_socket(sacn_thread_id_t thread_id, etcpal_socket_t socket, bool close_now)
+void sacn_remove_receiver_socket(sacn_thread_id_t thread_id, etcpal_socket_t *socket, bool close_now)
 {
-  SACN_ASSERT(socket != ETCPAL_SOCKET_INVALID);
+  SACN_ASSERT(socket != NULL);
+  SACN_ASSERT(*socket != ETCPAL_SOCKET_INVALID);
 
   SacnRecvThreadContext* context = get_recv_thread_context(thread_id);
   SACN_ASSERT(context);
 
-  cleanup_socket(context, socket, close_now);
+  cleanup_socket(context, *socket, close_now);
+
+  *socket = ETCPAL_SOCKET_INVALID;
 }
 
 /*

--- a/src/sacn_mock/private/sockets.h
+++ b/src/sacn_mock/private/sockets.h
@@ -32,7 +32,7 @@ DECLARE_FAKE_VOID_FUNC(sacn_sockets_deinit);
 DECLARE_FAKE_VALUE_FUNC(etcpal_error_t, sacn_validate_netint_config, SacnMcastInterface*, size_t, size_t*);
 DECLARE_FAKE_VALUE_FUNC(etcpal_error_t, sacn_add_receiver_socket, sacn_thread_id_t, etcpal_iptype_t, uint16_t,
                         const EtcPalMcastNetintId*, size_t, etcpal_socket_t*);
-DECLARE_FAKE_VOID_FUNC(sacn_remove_receiver_socket, sacn_thread_id_t, etcpal_socket_t, bool);
+DECLARE_FAKE_VOID_FUNC(sacn_remove_receiver_socket, sacn_thread_id_t, etcpal_socket_t*, bool);
 DECLARE_FAKE_VOID_FUNC(sacn_add_pending_sockets, SacnRecvThreadContext*);
 DECLARE_FAKE_VOID_FUNC(sacn_cleanup_dead_sockets, SacnRecvThreadContext*);
 DECLARE_FAKE_VALUE_FUNC(etcpal_error_t, sacn_read, SacnRecvThreadContext*, SacnReadResult*);

--- a/src/sacn_mock/sockets.c
+++ b/src/sacn_mock/sockets.c
@@ -24,7 +24,7 @@ DEFINE_FAKE_VOID_FUNC(sacn_sockets_deinit);
 DEFINE_FAKE_VALUE_FUNC(etcpal_error_t, sacn_validate_netint_config, SacnMcastInterface*, size_t, size_t*);
 DEFINE_FAKE_VALUE_FUNC(etcpal_error_t, sacn_add_receiver_socket, sacn_thread_id_t, etcpal_iptype_t, uint16_t,
                        const EtcPalMcastNetintId*, size_t, etcpal_socket_t*);
-DEFINE_FAKE_VOID_FUNC(sacn_remove_receiver_socket, sacn_thread_id_t, etcpal_socket_t, bool);
+DEFINE_FAKE_VOID_FUNC(sacn_remove_receiver_socket, sacn_thread_id_t, etcpal_socket_t*, bool);
 DEFINE_FAKE_VOID_FUNC(sacn_add_pending_sockets, SacnRecvThreadContext*);
 DEFINE_FAKE_VOID_FUNC(sacn_cleanup_dead_sockets, SacnRecvThreadContext*);
 DEFINE_FAKE_VALUE_FUNC(etcpal_error_t, sacn_read, SacnRecvThreadContext*, SacnReadResult*);

--- a/tests/unit/api/c/receiver/test_receiver.cpp
+++ b/tests/unit/api/c/receiver/test_receiver.cpp
@@ -115,8 +115,9 @@ TEST_F(TestReceiver, ChangeUniverseWorks)
   sacn_receiver_create(&config, &handle, nullptr, 0);
 
   clear_term_set_list_fake.custom_fake = [](TerminationSet* list) { EXPECT_EQ(list, nullptr); };
-  sacn_remove_receiver_socket_fake.custom_fake = [](sacn_thread_id_t thread_id, etcpal_socket_t socket, bool) {
-    EXPECT_EQ(socket, CHANGE_UNIVERSE_WORKS_FIRST_SOCKET);
+  sacn_remove_receiver_socket_fake.custom_fake = [](sacn_thread_id_t thread_id, etcpal_socket_t *socket, bool) {
+    ASSERT_NE(socket, nullptr);
+    EXPECT_EQ(*socket, CHANGE_UNIVERSE_WORKS_FIRST_SOCKET);
     EXPECT_NE(get_recv_thread_context(thread_id), nullptr);
   };
   sacn_add_receiver_socket_fake.custom_fake = [](sacn_thread_id_t thread_id, etcpal_iptype_t ip_type, uint16_t universe,

--- a/tests/unit/api/c/receiver/test_receiver.cpp
+++ b/tests/unit/api/c/receiver/test_receiver.cpp
@@ -36,7 +36,8 @@
 #define TestReceiver TestReceiverStatic
 #endif
 
-constexpr uint16_t CHANGE_UNIVERSE_WORKS_FIRST_SOCKET = 1u;
+constexpr uint16_t CHANGE_UNIVERSE_WORKS_FIRST_IPV4_SOCKET = 4u;
+constexpr uint16_t CHANGE_UNIVERSE_WORKS_FIRST_IPV6_SOCKET = 6u;
 constexpr uint16_t CHANGE_UNIVERSE_WORKS_FIRST_UNIVERSE = 1u;
 constexpr uint16_t CHANGE_UNIVERSE_WORKS_SECOND_UNIVERSE = 2u;
 constexpr uint16_t CHANGE_UNIVERSE_INVALID_UNIVERSE_1 = 0u;
@@ -65,6 +66,109 @@ protected:
   {
     sacn_receiver_deinit();
     sacn_mem_deinit();
+  }
+
+  void TestChangeUniverse(sacn_ip_support_t ip_supported)
+  {
+    SacnReceiverConfig config = SACN_RECEIVER_CONFIG_DEFAULT_INIT;
+    config.callbacks.universe_data = [](sacn_receiver_t, const EtcPalSockAddr*, const SacnHeaderData*, const uint8_t*,
+                                        bool, void*) {};
+    config.callbacks.sources_lost = [](sacn_receiver_t, uint16_t, const SacnLostSource*, size_t, void*) {};
+    config.callbacks.sampling_period_ended = [](sacn_receiver_t handle, uint16_t universe, void* context) {};
+    config.universe_id = CHANGE_UNIVERSE_WORKS_FIRST_UNIVERSE;
+    config.ip_supported = ip_supported;
+
+    sacn_add_receiver_socket_fake.custom_fake = [](sacn_thread_id_t, etcpal_iptype_t ip_type, uint16_t,
+                                                   const EtcPalMcastNetintId*, size_t, etcpal_socket_t* socket) {
+      if (ip_type == kEtcPalIpTypeV4)
+        *socket = CHANGE_UNIVERSE_WORKS_FIRST_IPV4_SOCKET;
+      else if (ip_type == kEtcPalIpTypeV6)
+        *socket = CHANGE_UNIVERSE_WORKS_FIRST_IPV6_SOCKET;
+      return kEtcPalErrOk;
+    };
+
+    sacn_receiver_t handle;
+    sacn_receiver_create(&config, &handle, nullptr, 0);
+
+    clear_term_set_list_fake.custom_fake = [](TerminationSet* list) { EXPECT_EQ(list, nullptr); };
+
+    switch (ip_supported)
+    {
+      case kSacnIpV4Only:
+        sacn_remove_receiver_socket_fake.custom_fake = [](sacn_thread_id_t thread_id, etcpal_socket_t* socket, bool) {
+          ASSERT_NE(socket, nullptr);
+          EXPECT_NE(*socket, CHANGE_UNIVERSE_WORKS_FIRST_IPV6_SOCKET);
+          EXPECT_NE(get_recv_thread_context(thread_id), nullptr);
+        };
+        sacn_add_receiver_socket_fake.custom_fake = [](sacn_thread_id_t thread_id, etcpal_iptype_t ip_type,
+                                                       uint16_t universe, const EtcPalMcastNetintId*, size_t,
+                                                       etcpal_socket_t* socket) {
+          EXPECT_NE(ip_type, kEtcPalIpTypeV6);
+          EXPECT_NE(ip_type, kEtcPalIpTypeInvalid);
+          EXPECT_EQ(universe, CHANGE_UNIVERSE_WORKS_SECOND_UNIVERSE);
+          EXPECT_NE(get_recv_thread_context(thread_id), nullptr);
+          EXPECT_NE(socket, nullptr);
+          return kEtcPalErrOk;
+        };
+        break;
+      case kSacnIpV6Only:
+        sacn_remove_receiver_socket_fake.custom_fake = [](sacn_thread_id_t thread_id, etcpal_socket_t* socket, bool) {
+          ASSERT_NE(socket, nullptr);
+          EXPECT_NE(*socket, CHANGE_UNIVERSE_WORKS_FIRST_IPV4_SOCKET);
+          EXPECT_NE(get_recv_thread_context(thread_id), nullptr);
+        };
+        sacn_add_receiver_socket_fake.custom_fake = [](sacn_thread_id_t thread_id, etcpal_iptype_t ip_type,
+                                                       uint16_t universe, const EtcPalMcastNetintId*, size_t,
+                                                       etcpal_socket_t* socket) {
+          EXPECT_NE(ip_type, kEtcPalIpTypeV4);
+          EXPECT_NE(ip_type, kEtcPalIpTypeInvalid);
+          EXPECT_EQ(universe, CHANGE_UNIVERSE_WORKS_SECOND_UNIVERSE);
+          EXPECT_NE(get_recv_thread_context(thread_id), nullptr);
+          EXPECT_NE(socket, nullptr);
+          return kEtcPalErrOk;
+        };
+        break;
+      case kSacnIpV4AndIpV6:
+        sacn_remove_receiver_socket_fake.custom_fake = [](sacn_thread_id_t thread_id, etcpal_socket_t* socket, bool) {
+          ASSERT_NE(socket, nullptr);
+          EXPECT_NE(get_recv_thread_context(thread_id), nullptr);
+        };
+        sacn_add_receiver_socket_fake.custom_fake = [](sacn_thread_id_t thread_id, etcpal_iptype_t ip_type,
+                                                       uint16_t universe, const EtcPalMcastNetintId*, size_t,
+                                                       etcpal_socket_t* socket) {
+          EXPECT_NE(ip_type, kEtcPalIpTypeInvalid);
+          EXPECT_EQ(universe, CHANGE_UNIVERSE_WORKS_SECOND_UNIVERSE);
+          EXPECT_NE(get_recv_thread_context(thread_id), nullptr);
+          EXPECT_NE(socket, nullptr);
+          return kEtcPalErrOk;
+        };
+    }
+
+    etcpal_error_t change_universe_result =
+        sacn_receiver_change_universe(handle, CHANGE_UNIVERSE_WORKS_SECOND_UNIVERSE);
+
+    EXPECT_EQ(change_universe_result, kEtcPalErrOk);
+    EXPECT_EQ(sacn_lock_fake.call_count, sacn_unlock_fake.call_count);
+    EXPECT_EQ(sacn_initialized_fake.call_count, 2u);
+    EXPECT_EQ(clear_term_set_list_fake.call_count, 1u);
+
+    switch (ip_supported)
+    {
+      case kSacnIpV4Only:
+      case kSacnIpV6Only:
+        EXPECT_EQ(sacn_remove_receiver_socket_fake.call_count, 1u);
+        EXPECT_EQ(sacn_add_receiver_socket_fake.call_count, 2u);
+        break;
+      case kSacnIpV4AndIpV6:
+        EXPECT_EQ(sacn_remove_receiver_socket_fake.call_count, 2u);
+        EXPECT_EQ(sacn_add_receiver_socket_fake.call_count, 4u);
+    }
+
+    clear_term_set_list_fake.custom_fake = nullptr;
+    sacn_remove_receiver_socket_fake.custom_fake = nullptr;
+    sacn_add_receiver_socket_fake.custom_fake = nullptr;
+
+    sacn_receiver_destroy(handle);
   }
 };
 
@@ -96,54 +200,19 @@ TEST_F(TestReceiver, SetExpiredWaitWorks)
   EXPECT_EQ(sacn_receiver_get_expired_wait(), std::numeric_limits<uint32_t>::max());
 }
 
-TEST_F(TestReceiver, ChangeUniverseWorks)
+TEST_F(TestReceiver, ChangeUniverseV4Works)
 {
-  SacnReceiverConfig config = SACN_RECEIVER_CONFIG_DEFAULT_INIT;
-  config.callbacks.universe_data = [](sacn_receiver_t, const EtcPalSockAddr*, const SacnHeaderData*, const uint8_t*,
-                                      bool, void*) {};
-  config.callbacks.sources_lost = [](sacn_receiver_t, uint16_t, const SacnLostSource*, size_t, void*) {};
-  config.callbacks.sampling_period_ended = [](sacn_receiver_t handle, uint16_t universe, void* context) {};
-  config.universe_id = CHANGE_UNIVERSE_WORKS_FIRST_UNIVERSE;
+  TestChangeUniverse(kSacnIpV4Only);
+}
 
-  sacn_add_receiver_socket_fake.custom_fake = [](sacn_thread_id_t, etcpal_iptype_t, uint16_t, const EtcPalMcastNetintId*,
-                                                 size_t, etcpal_socket_t* socket) {
-    *socket = CHANGE_UNIVERSE_WORKS_FIRST_SOCKET;
-    return kEtcPalErrOk;
-  };
+TEST_F(TestReceiver, ChangeUniverseV6Works)
+{
+  TestChangeUniverse(kSacnIpV6Only);
+}
 
-  sacn_receiver_t handle;
-  sacn_receiver_create(&config, &handle, nullptr, 0);
-
-  clear_term_set_list_fake.custom_fake = [](TerminationSet* list) { EXPECT_EQ(list, nullptr); };
-  sacn_remove_receiver_socket_fake.custom_fake = [](sacn_thread_id_t thread_id, etcpal_socket_t *socket, bool) {
-    ASSERT_NE(socket, nullptr);
-    EXPECT_EQ(*socket, CHANGE_UNIVERSE_WORKS_FIRST_SOCKET);
-    EXPECT_NE(get_recv_thread_context(thread_id), nullptr);
-  };
-  sacn_add_receiver_socket_fake.custom_fake = [](sacn_thread_id_t thread_id, etcpal_iptype_t ip_type, uint16_t universe,
-                                                 const EtcPalMcastNetintId*, size_t, etcpal_socket_t* socket) {
-    EXPECT_NE(ip_type, kEtcPalIpTypeInvalid);
-    EXPECT_EQ(universe, CHANGE_UNIVERSE_WORKS_SECOND_UNIVERSE);
-    EXPECT_NE(get_recv_thread_context(thread_id), nullptr);
-    EXPECT_NE(socket, nullptr);
-
-    return kEtcPalErrOk;
-  };
-
-  etcpal_error_t change_universe_result = sacn_receiver_change_universe(handle, CHANGE_UNIVERSE_WORKS_SECOND_UNIVERSE);
-
-  EXPECT_EQ(change_universe_result, kEtcPalErrOk);
-  EXPECT_EQ(sacn_lock_fake.call_count, sacn_unlock_fake.call_count);
-  EXPECT_EQ(sacn_initialized_fake.call_count, 2u);
-  EXPECT_EQ(clear_term_set_list_fake.call_count, 1u);
-  EXPECT_EQ(sacn_remove_receiver_socket_fake.call_count, 2u);
-  EXPECT_EQ(sacn_add_receiver_socket_fake.call_count, 4u);
-
-  clear_term_set_list_fake.custom_fake = nullptr;
-  sacn_remove_receiver_socket_fake.custom_fake = nullptr;
-  sacn_add_receiver_socket_fake.custom_fake = nullptr;
-
-  sacn_receiver_destroy(handle);
+TEST_F(TestReceiver, ChangeUniverseV4V6Works)
+{
+  TestChangeUniverse(kSacnIpV4AndIpV6);
 }
 
 TEST_F(TestReceiver, ChangeUniverseErrInvalidWorks)
@@ -219,8 +288,7 @@ TEST_F(TestReceiver, ChangeUniverseErrNotFoundWorks)
   sacn_receiver_t handle;
   sacn_receiver_create(&config, &handle, nullptr, 0);
 
-  etcpal_error_t change_universe_found_result =
-      sacn_receiver_change_universe(handle, CHANGE_UNIVERSE_VALID_UNIVERSE_2);
+  etcpal_error_t change_universe_found_result = sacn_receiver_change_universe(handle, CHANGE_UNIVERSE_VALID_UNIVERSE_2);
   EXPECT_NE(change_universe_found_result, kEtcPalErrNotFound);
 }
 


### PR DESCRIPTION
This is an implementation of the ip_supported setting in the receiver configuration. This has also been added to the unit tests for change universe.