### PR TITLE
Provide more specific error statuses in SacnMcastInterface::status

### DIFF
--- a/src/sacn/sockets.c
+++ b/src/sacn/sockets.c
@@ -513,11 +513,16 @@ etcpal_error_t sacn_validate_netint_config(SacnMcastInterface* netints, size_t n
 
     for (SacnMcastInterface* netint = netints; netint < (netints + num_netints); ++netint)
     {
-      netint->status = kEtcPalErrSys;  // TODO: Consider more specific error codes here.
-
-      if ((netint->iface.index != 0) &&
-          ((netint->iface.ip_type == kEtcPalIpTypeV4) || (netint->iface.ip_type == kEtcPalIpTypeV6)) &&
-          (netint_id_index_in_array(&netint->iface, valid_sys_netints, num_valid_sys_netints) != -1))
+      if ((netint->iface.index == 0) || (netint->iface.ip_type == kEtcPalIpTypeInvalid))
+      {
+        netint->status = kEtcPalErrInvalid;
+      }
+      else if (netint_id_index_in_array(&netint->iface, valid_sys_netints, num_valid_sys_netints) == -1)
+      {
+        netint->status = kEtcPalErrNetwork;
+        // TODO: Pass on the specific error codes from each failed netint test
+      }
+      else
       {
         netint->status = kEtcPalErrOk;
         all_interfaces_invalid = false;

--- a/src/sacn/sockets.c
+++ b/src/sacn/sockets.c
@@ -53,7 +53,7 @@ static size_t num_sys_netints;
 
 static etcpal_error_t test_sacn_netint(const EtcPalMcastNetintId* netint_id, const char* addr_str);
 static void add_sacn_netint(const EtcPalMcastNetintId* netint_id, etcpal_error_t status);
-static int netint_id_index_in_array(const EtcPalMcastNetintId* id, const EtcPalMcastNetintId* array, size_t array_size);
+static int netint_id_index_in_array(const EtcPalMcastNetintId* id, const SacnMcastInterface* array, size_t array_size);
 
 static etcpal_error_t create_send_socket(const EtcPalMcastNetintId* netint_id, etcpal_socket_t* socket);
 static etcpal_error_t create_receiver_socket(etcpal_iptype_t ip_type, const EtcPalSockAddr* bind_addr,


### PR DESCRIPTION
I ended up adjusting a few things here. SACN_MAX_NETINTS now refers to the maximum number of total interfaces that can be processed by sACN, instead of just the valid ones (although it was already partially the former). Now sACN is tracking all interfaces because it is tracking the error codes of the failed interfaces in addition to the valid ones.

SACN_MAX_NETINTS has the same documentation but let me know if you want it adjusted: "The maximum number of network interfaces that can used by the sACN library. Meaningful only if #SACN_DYNAMIC_MEM is defined to 0."

I am passing along the error statuses directly from the failed netint test operations. I'm currently not doing any filtering of these statuses beyond that, but let me know if there should be.