### PR TITLE
Per-address priority documentation changes

### DIFF
--- a/docs/pages/per_address_priority.md
+++ b/docs/pages/per_address_priority.md
@@ -9,7 +9,7 @@ To better handle multiple source control scenarios, the 0xDD sACN start code was
 The following acronyms and terms are used:
 - *sACN*,  *Streaming ACN*, *Streaming DMX*: Reference “BSR E1.31 DMX512-A Streaming Protocol”
 - *Receiver*: A device that receives sACN
-- *Source*: A device that send sACN. Sources are uniquely identified by their CID number.
+- *Source*: A device that sends sACN. Sources are uniquely identified by their CID number.
 - *DMX level(s)*: Property values associated with a Null START code data packet.
 - *HTP*: Highest Takes Precedence: The source with the highest level will have control.
 - *Packet priority field*: Value of priority field in an sACN packet.
@@ -34,15 +34,13 @@ The following acronyms and terms are used:
 7. Per-address priorities for sources that do not send 0xDD packets will be taken from the packet priority field. 
 8. The source follows the sACN rules for non-changing data for 0xDD packets as well, so a change of priorities for a universe is sent for 3 extra frames and then sent once every 800-1000ms. 
 9. When a source wants to take control of an address, it should set desired DMX level and then set the per-address priority to a non-0 value.
-10.	When a source wants to give up control of an address, it sets the per-address priority to a 0 value.  It is recommended that it subsequently sends out DMX levels of 0 for that address.
-11.	Setting a priority to zero may result in source loss behavior for the corresponding address if there is no other source that gets control.  
-It may be desirable for sources to provide a user configurable option to also set the data to 0 before setting the priority to 0.
-12. For some compatibility with receivers that don’t support the 0xDD packets, sources sending 0xDD packets shall also provide a packet priority value that applies to all addresses.  The default value for this priority shall be 100.  This allows for packet priority and HTP control between sources.
-13. When a receiver detects a new source, it waits for a 0xDD packet for up to 1.5 seconds before processing DMX levels from that source.  If a receiver does not detect a 0xDD packet, it fails back and uses the packet priority until a 0xDD packet is detected.   
-14.	When a receiver detects that a source has reached the sACN source loss timeout for 0xDD packets (e.g. no 0xDD packets in Universal Hold Last Look Time--2.5 seconds at minimum), but is still receiving NULL start code packets, the receiver shall fall back to using the sACN packet priority located in the NULL start code packets.
-15. When a receiver detects that a source has reached the sACN source loss timeout for NULL start code packets (e.g. no NULL start code packets in the Universal Hold Last Look Time--2.5 seconds at minimum) the receiver shall act as if the source has given up control of its addresses as stated in 4.16 even if 0xDD packets continue to be received.  
-The desired sequence for a source to terminate its sACN stream is to send three packets with the Stream_Terminated bit (6) of the Packet options field set to 1.  This will allow the device with the next highest priority to gain control after the appropriate sampling time resolution.
-16. When a receiver detects that a source has given up control of an address (by setting the priority for that address to 0), the receiver will give control to the source with next highest priority. If no source is available, source loss behavior for that address shall apply.
+10.	When a source wants to give up control of an address, it should set the per-address priority to zero. It is recommended to also set the DMX level to zero, because setting a priority to zero may result in source loss behavior for the corresponding address if there is no other source that gets control.
+11. For some compatibility with receivers that don’t support the 0xDD packets, sources sending 0xDD packets shall also provide a packet priority value that applies to all addresses.  The default value for this priority shall be 100.  This allows for packet priority and HTP control between sources.
+12. When a receiver detects a new source, it waits for a 0xDD packet for up to 1.5 seconds before processing DMX levels from that source.  If a receiver does not detect a 0xDD packet, it falls back and uses the packet priority until a 0xDD packet is detected.   
+13.	When a receiver detects that a source has reached the sACN source loss timeout for 0xDD packets (e.g. no 0xDD packets in Universal Hold Last Look Time--2.5 seconds at minimum), but is still receiving NULL start code packets, the receiver shall fall back to using the sACN packet priority located in the NULL start code packets.
+14. When a receiver detects that a source has reached the sACN source loss timeout for NULL start code packets (e.g. no NULL start code packets in the Universal Hold Last Look Time--2.5 seconds at minimum) the receiver shall act as if the source has given up control of its addresses as stated in 4.16 even if 0xDD packets continue to be received.  
+The desired sequence for a source to terminate its sACN stream is to send three NULL start code packets with the Stream_Terminated bit (6) of the Packet options field set to 1.  This will allow the device with the next highest priority to gain control after the appropriate sampling time resolution.
+15. When a receiver detects that a source has given up control of an address (by setting the priority for that address to 0), the receiver will give control to the source with next highest priority. If no source is available, source loss behavior for that address shall apply.
 
 # Summary
 In summary, priority may be specified on a per packet basis in sACN. This ETC extension allows priorities to be provided on a per-address basis using the alternate start code of 0xDD.

--- a/docs/pages/per_address_priority.md
+++ b/docs/pages/per_address_priority.md
@@ -9,7 +9,7 @@ To better handle multiple source control scenarios, the 0xDD sACN start code was
 The following acronyms and terms are used:
 - *sACN*,  *Streaming ACN*, *Streaming DMX*: Reference “BSR E1.31 DMX512-A Streaming Protocol”
 - *Receiver*: A device that receives sACN
-- *Source*: A device that sends sACN. Sources are uniquely identified by their CID number.
+- *Source*: A device that sends sACN. Sources are uniquely identified by their CID.
 - *DMX level(s)*: Property values associated with a Null START code data packet.
 - *HTP*: Highest Takes Precedence: The source with the highest level will have control.
 - *Packet priority field*: Value of priority field in an sACN packet.

--- a/src/sacn/source.c
+++ b/src/sacn/source.c
@@ -773,18 +773,20 @@ void sacn_source_update_values(sacn_source_t handle, uint16_t universe, const ui
  * This function will update the outgoing packet values for both DMX and per-address priority data, and reset the logic
  * that slows down packet transmission due to inactivity.
  *
- * Per-address priority support has specific rules about when to send value changes vs. pap changes.  These rules are
- * documented in https://etclabs.github.io/sACN/docs/head/per_address_priority.html, and are triggered by the use of
- * this function. Changing per-address priorities to and from "don't care", changing the size of the priorities array,
- * or passing in NULL/non-NULL for the priorities will cause this library to do the necessary tasks to "take control" or
- * "release control" of the corresponding DMX values.
+ * The application should adhere to the rules for per-address priority (PAP) specified in
+ * https://etclabs.github.io/sACN/docs/head/per_address_priority.html. This API will adhere to the rules within the
+ * scope of the implementation, which involve handling transmission suppression and the order in which DMX and PAP
+ * packets are sent. For each slot the application releases control of (by setting the PAP to 0 or reducing the number
+ * of PAPs), it is recommended that the application also set that slot's corresponding DMX level to 0. This is left to
+ * the application.
  *
  * @param[in] handle Handle to the source to update.
  * @param[in] universe Universe to update.
  * @param[in] new_values A buffer of dmx values to copy from. This pointer must not be NULL.
  * @param[in] new_values_size Size of new_values. This must be no larger than #DMX_ADDRESS_COUNT.
- * @param[in] new_priorities A buffer of per-address priorities to copy from. This may be NULL if you are not using
- * per-address priorities or want to stop using per-address priorities.
+ * @param[in] new_priorities A buffer of per-address priorities to copy from. Setting this to NULL will stop the
+ * transmission of per-address priorities, in which case receivers will revert to the universe priority after PAP times
+ * out.
  * @param[in] new_priorities_size Size of new_priorities. This must be no larger than #DMX_ADDRESS_COUNT.
  */
 void sacn_source_update_values_and_pap(sacn_source_t handle, uint16_t universe, const uint8_t* new_values,
@@ -848,11 +850,12 @@ void sacn_source_update_values_and_force_sync(sacn_source_t handle, uint16_t uni
  * the logic that slows down packet transmission due to inactivity. Additionally, both packets to be sent by this call
  * will have their force_synchronization option flags set.
  *
- * Per-address priority support has specific rules about when to send value changes vs. pap changes.  These rules are
- * documented in https://etclabs.github.io/sACN/docs/head/per_address_priority.html, and are triggered by the use of
- * this function. Changing per-address priorities to and from "don't care", changing the size of the priorities array,
- * or passing in NULL/non-NULL for the priorities will cause this library to do the necessary tasks to "take control" or
- * "release control" of the corresponding DMX values.
+ * The application should adhere to the rules for per-address priority (PAP) specified in
+ * https://etclabs.github.io/sACN/docs/head/per_address_priority.html. This API will adhere to the rules within the
+ * scope of the implementation, which involve handling transmission suppression and the order in which DMX and PAP
+ * packets are sent. For each slot the application releases control of (by setting the PAP to 0 or reducing the number
+ * of PAPs), it is recommended that the application also set that slot's corresponding DMX level to 0. This is left to
+ * the application.
  *
  * If no synchronization universe is configured, this function acts like a direct call to
  * sacn_source_update_values_and_pap().
@@ -863,8 +866,9 @@ void sacn_source_update_values_and_force_sync(sacn_source_t handle, uint16_t uni
  * @param[in] universe Universe to update.
  * @param[in] new_values A buffer of dmx values to copy from. This pointer must not be NULL.
  * @param[in] new_values_size Size of new_values. This must be no larger than #DMX_ADDRESS_COUNT.
- * @param[in] new_priorities A buffer of per-address priorities to copy from. This may be NULL if you are not using
- * per-address priorities or want to stop using per-address priorities.
+ * @param[in] new_priorities A buffer of per-address priorities to copy from. Setting this to NULL will stop the
+ * transmission of per-address priorities, in which case receivers will revert to the universe priority after PAP times
+ * out.
  * @param[in] new_priorities_size Size of new_priorities. This must be no larger than #DMX_ADDRESS_COUNT.
  */
 void sacn_source_update_values_and_pap_and_force_sync(sacn_source_t handle, uint16_t universe,


### PR DESCRIPTION
I went through and made numerous improvements to the PAP documentation to bring it closer to how our library is implemented and the use cases we'll need to support. There were a couple of contradictory rules regarding the ordering of 0x00 and 0xDD packets which have been resolved. The rule for making this order configurable has been removed. I clarified how responsibilities for adhering to these rules are divided between the application and the API. Other minor fixes as well.