### PR TITLE
Source API treats terminating sources/universes/dests as removed

### DIFF
--- a/include/sacn/cpp/source.h
+++ b/include/sacn/cpp/source.h
@@ -281,9 +281,9 @@ inline etcpal::Error Source::Startup(const Settings& settings)
 /**
  * @brief Destroy an sACN source instance.
  *
- * Stops sending all universes for this source. The destruction is queued, and actually occurs either on the thread or
- * on a call to ProcessManual() after an additional three packets have been sent with the "Stream_Terminated" option
- * set. The source will also stop transmitting sACN universe discovery packets.
+ * Stops sending all universes for this source. This removes the source and queues the sending of termination packets to
+ * all of the source's universes, which takes place either on the thread or on calls to ProcessManual().
+ * The source will also stop transmitting sACN universe discovery packets.
  */
 inline void Source::Shutdown()
 {
@@ -379,10 +379,10 @@ inline etcpal::Error Source::AddUniverse(const UniverseSettings& settings, std::
 /**
  * @brief Remove a universe from a source.
  *
- * This queues the universe for removal. The destruction actually occurs either on the thread or on a call to
- * ProcessManual() after an additional three packets have been sent with the "Stream_Terminated" option set.
+ * This removes a universe and queues the sending of termination packets to the universe, which takes place either on
+ * the thread or on calls to ProcessManual().
  *
- * The source will also stop transmitting sACN universe discovery packets for that universe.
+ * The source will also stop including the universe in sACN universe discovery packets.
  *
  * @param[in] universe Universe to remove.
  */
@@ -436,8 +436,8 @@ inline etcpal::Error Source::AddUnicastDestination(uint16_t universe, const etcp
 /**
  * @brief Remove a unicast destination on a universe.
  *
- * This queues the address for removal. The removal actually occurs either on the thread or on a call to ProcessManual()
- * after an additional three packets have been sent with the "Stream_Terminated" option set.
+ * This removes a unicast destination address and queues the sending of termination packets to the address, which takes
+ * place either on the thread or on calls to ProcessManual().
  *
  * @param[in] universe Universe to change.
  * @param[in] dest The destination IP.  Must match the address passed to AddUnicastDestination().
@@ -700,9 +700,9 @@ inline void Source::UpdateValuesAndForceSync(uint16_t universe, const uint8_t* n
  * haven't been updated. Also destroys sources & universes that have been marked for termination after sending the
  * required three terminated packets.
  *
- * @return Current number of manual sources tracked by the library. This can be useful on shutdown to
- *         track when destroyed sources have finished sending the terminated packets and actually
- *         been destroyed.
+ * @return Current number of manual sources tracked by the library, including sources that have been destroyed but are
+ * still sending termination packets. This can be useful on shutdown to track when destroyed sources have finished
+ * sending the terminated packets and actually been destroyed.
  */
 inline int Source::ProcessManual()
 {

--- a/include/sacn/cpp/source.h
+++ b/include/sacn/cpp/source.h
@@ -384,7 +384,8 @@ inline etcpal::Error Source::AddUniverse(const UniverseSettings& settings, std::
  *
  * The source will also stop including the universe in sACN universe discovery packets.
  *
- * @param[in] universe Universe to remove.
+ * @param[in] universe Universe to remove. This source's functions will no longer recognize this universe unless the
+ * universe is re-added.
  */
 inline void Source::RemoveUniverse(uint16_t universe)
 {
@@ -440,7 +441,7 @@ inline etcpal::Error Source::AddUnicastDestination(uint16_t universe, const etcp
  * place either on the thread or on calls to ProcessManual().
  *
  * @param[in] universe Universe to change.
- * @param[in] dest The destination IP.  Must match the address passed to AddUnicastDestination().
+ * @param[in] dest The destination IP to remove.  Must match the address passed to AddUnicastDestination().
  */
 inline void Source::RemoveUnicastDestination(uint16_t universe, const etcpal::IpAddr& dest)
 {

--- a/src/sacn/source.c
+++ b/src/sacn/source.c
@@ -211,7 +211,7 @@ etcpal_error_t sacn_source_change_name(sacn_source_t handle, const char* new_nam
  * all of the source's universes, which takes place either on the thread or on calls to sacn_source_process_manual().
  * The source will also stop transmitting sACN universe discovery packets.
  *
- * @param[in] handle Handle to the source to destroy.
+ * @param[in] handle Handle to the source to destroy. This handle will no longer be usable with the source API.
  */
 void sacn_source_destroy(sacn_source_t handle)
 {
@@ -325,7 +325,8 @@ etcpal_error_t sacn_source_add_universe(sacn_source_t handle, const SacnSourceUn
  * The source will also stop including the universe in sACN universe discovery packets.
  *
  * @param[in] handle Handle to the source from which to remove the universe.
- * @param[in] universe Universe to remove.
+ * @param[in] universe Universe to remove. The source API functions will no longer recognize this universe for this
+ * source unless the universe is re-added to the source.
  */
 void sacn_source_remove_universe(sacn_source_t handle, uint16_t universe)
 {
@@ -440,7 +441,7 @@ etcpal_error_t sacn_source_add_unicast_destination(sacn_source_t handle, uint16_
  *
  * @param[in] handle Handle to the source to change.
  * @param[in] universe Universe to change.
- * @param[in] dest The destination IP.  May not be NULL, and must match the address passed to
+ * @param[in] dest The destination IP to remove.  May not be NULL, and must match the address passed to
  * sacn_source_add_unicast_destination().
  */
 void sacn_source_remove_unicast_destination(sacn_source_t handle, uint16_t universe, const EtcPalIpAddr* dest)

--- a/src/sacn/source_state.c
+++ b/src/sacn/source_state.c
@@ -610,20 +610,38 @@ void set_source_name(SacnSource* source, const char* new_name)
 // Needs lock
 size_t get_source_universes(const SacnSource* source, uint16_t* universes, size_t universes_size)
 {
-  for (size_t i = 0; (i < source->num_universes) && universes && (i < universes_size); ++i)
-    universes[i] = source->universes[i].universe_id;
+  size_t num_non_terminating_universes = 0;
+  for (size_t read = 0; (read < source->num_universes); ++read)
+  {
+    if (!source->universes[read].terminating)
+    {
+      if (universes && (num_non_terminating_universes < universes_size))
+        universes[num_non_terminating_universes] = source->universes[read].universe_id;
 
-  return source->num_universes;
+      ++num_non_terminating_universes;
+    }
+  }
+
+  return num_non_terminating_universes;
 }
 
 // Needs lock
 size_t get_source_unicast_dests(const SacnSourceUniverse* universe, EtcPalIpAddr* destinations,
                                 size_t destinations_size)
 {
-  for (size_t i = 0; (i < universe->num_unicast_dests) && destinations && (i < destinations_size); ++i)
-    destinations[i] = universe->unicast_dests[i].dest_addr;
+  size_t num_non_terminating_dests = 0;
+  for (size_t read = 0; (read < universe->num_unicast_dests); ++read)
+  {
+    if (!universe->unicast_dests[read].terminating)
+    {
+      if (destinations && (num_non_terminating_dests < destinations_size))
+        destinations[num_non_terminating_dests] = universe->unicast_dests[read].dest_addr;
 
-  return universe->num_unicast_dests;
+      ++num_non_terminating_dests;
+    }
+  }
+
+  return num_non_terminating_dests;
 }
 
 // Needs lock

--- a/tests/unit/api/c/source/test_source.cpp
+++ b/tests/unit/api/c/source/test_source.cpp
@@ -381,7 +381,7 @@ TEST_F(TestSource, SourceSendNowWorks)
     EXPECT_EQ(universe->universe_id, kTestUniverse);
     EXPECT_EQ(send_buf[SACN_DATA_HEADER_SIZE - 1], kTestStartCode);
     EXPECT_EQ(memcmp(&send_buf[SACN_DATA_HEADER_SIZE], kTestBuffer, kTestBufferLength), 0);
-    EXPECT_EQ(behavior, kIncludeTerminatingUnicastDests);
+    EXPECT_EQ(behavior, kSkipTerminatingUnicastDests);
   };
   increment_sequence_number_fake.custom_fake = [](SacnSourceUniverse* universe) {
     EXPECT_EQ(universe->universe_id, kTestUniverse);


### PR DESCRIPTION
When I was writing unit tests I discovered an edge case where the application could technically modify (or at least access) the state of a source, universe, or unicast destination that is being removed (termination packets are being sent, so the underlying state is still there). This could be problematic and could open the door to bugs. This is my proposed solution. If a source/universe/dest is terminating but hasn't finished yet, the outward-facing API will still treat it as if it were removed and could not be found. I also adjusted the documentation a bit for this.