### PR TITLE
Unit tests for source_state module part 3

### DIFF
--- a/tests/unit/state/source/test_source_state.cpp
+++ b/tests/unit/state/source/test_source_state.cpp
@@ -1014,6 +1014,23 @@ TEST_F(TestSourceState, TerminatingUnicastDestsOnlySendTerminations)
     etcpal_getms_fake.return_val += 100u;
     VERIFY_LOCKING(take_lock_and_process_sources(kProcessThreadedSources));
   }
+}
 
-  sacn_send_unicast_fake.custom_fake = [](sacn_ip_support_t, const uint8_t*, const EtcPalIpAddr*) {};
+TEST_F(TestSourceState, PapNotTransmittedIfNotAdded)
+{
+  sacn_send_unicast_fake.custom_fake = [](sacn_ip_support_t, const uint8_t* send_buf, const EtcPalIpAddr*) {
+    uint8_t start_code = send_buf[SACN_DATA_HEADER_SIZE - 1];
+    EXPECT_EQ(start_code, 0x00u);
+  };
+
+  sacn_source_t source = AddSource(kTestSourceConfig);
+  AddUniverse(source, kTestUniverseConfig, kTestNetints, NUM_TEST_NETINTS);
+  InitTestData(source, kTestUniverseConfig.universe, kTestBuffer, kTestBufferLength);
+  AddTestUnicastDests(source, kTestUniverseConfig.universe);
+
+  for (int i = 0; i < 100; ++i)
+  {
+    etcpal_getms_fake.return_val += 100u;
+    VERIFY_LOCKING(take_lock_and_process_sources(kProcessThreadedSources));
+  }
 }

--- a/tests/unit/state/source/test_source_state.cpp
+++ b/tests/unit/state/source/test_source_state.cpp
@@ -1034,3 +1034,25 @@ TEST_F(TestSourceState, PapNotTransmittedIfNotAdded)
     VERIFY_LOCKING(take_lock_and_process_sources(kProcessThreadedSources));
   }
 }
+
+TEST_F(TestSourceState, SourcesTerminateCorrectly)
+{
+  sacn_source_t source = AddSource(kTestSourceConfig);
+  SacnSourceUniverseConfig universe_config = kTestUniverseConfig;
+  for (universe_config.universe = 1; universe_config.universe <= 10u; ++universe_config.universe)
+  {
+    AddUniverse(source, universe_config, kTestNetints, NUM_TEST_NETINTS);
+    AddTestUnicastDests(source, universe_config.universe);
+    InitTestData(source, universe_config.universe, kTestBuffer, kTestBufferLength);
+  }
+
+  set_source_terminating(GetSource(source));
+
+  for (int i = 0; i < 3; ++i)
+  {
+    EXPECT_NE(GetSource(source), nullptr);
+    VERIFY_LOCKING(take_lock_and_process_sources(kProcessThreadedSources));
+  }
+
+  EXPECT_EQ(GetSource(source), nullptr);
+}

--- a/tests/unit/state/source/test_source_state.cpp
+++ b/tests/unit/state/source/test_source_state.cpp
@@ -205,18 +205,34 @@ protected:
       if (IS_UNIVERSE_DATA(send_buf))
       {
         if (memcmp(&send_buf[SACN_DATA_HEADER_SIZE], kTestBuffer, kTestBufferLength) == 0)
+        {
           ++num_level_multicast_sends;
+          EXPECT_EQ(num_level_multicast_sends, num_pap_multicast_sends + current_netint_index + 1);
+        }
         else if (memcmp(&send_buf[SACN_DATA_HEADER_SIZE], kTestBuffer2, kTestBuffer2Length) == 0)
+        {
           ++num_pap_multicast_sends;
+          EXPECT_EQ(num_pap_multicast_sends, (num_level_multicast_sends - NUM_TEST_NETINTS) + current_netint_index + 1);
+        }
+
+        current_netint_index = (current_netint_index + 1) % NUM_TEST_NETINTS;
       }
     };
     sacn_send_unicast_fake.custom_fake = [](sacn_ip_support_t, const uint8_t* send_buf, const EtcPalIpAddr*) {
       if (IS_UNIVERSE_DATA(send_buf))
       {
         if (memcmp(&send_buf[SACN_DATA_HEADER_SIZE], kTestBuffer, kTestBufferLength) == 0)
+        {
           ++num_level_unicast_sends;
+          EXPECT_EQ(num_level_unicast_sends, num_pap_unicast_sends + current_remote_addr_index + 1);
+        }
         else if (memcmp(&send_buf[SACN_DATA_HEADER_SIZE], kTestBuffer2, kTestBuffer2Length) == 0)
+        {
           ++num_pap_unicast_sends;
+          EXPECT_EQ(num_pap_unicast_sends, (num_level_unicast_sends - NUM_TEST_ADDRS) + current_remote_addr_index + 1);
+        }
+
+        current_remote_addr_index = (current_remote_addr_index + 1) % NUM_TEST_ADDRS;
       }
     };
 
@@ -226,6 +242,9 @@ protected:
     uint16_t universe = AddUniverse(source, kTestUniverseConfig);
     AddTestUnicastDests(source, universe);
     InitTestData(source, universe, kTestBuffer, kTestBufferLength, kTestBuffer2, kTestBuffer2Length);
+
+    current_netint_index = 0;
+    current_remote_addr_index = 0;
 
     for (int i = 0; i < 5; ++i)
     {
@@ -902,17 +921,17 @@ TEST_F(TestSourceState, UniverseRemovalUpdatesSourceNetints)
   EXPECT_EQ(GetSource(source)->num_netints, 0u);
 }
 
-TEST_F(TestSourceState, SourceTransmitsLevelsAndPapsAtDefaultInterval)
+TEST_F(TestSourceState, TransmitsLevelsAndPapsCorrectlyAtDefaultInterval)
 {
   TestLevelPapTransmission(SACN_SOURCE_KEEP_ALIVE_INTERVAL_DEFAULT);
 }
 
-TEST_F(TestSourceState, SourceTransmitsLevelsAndPapsAtShortInterval)
+TEST_F(TestSourceState, TransmitsLevelsAndPapsCorrectlyAtShortInterval)
 {
   TestLevelPapTransmission(100);
 }
 
-TEST_F(TestSourceState, SourceTransmitsLevelsAndPapsAtLongInterval)
+TEST_F(TestSourceState, TransmitsLevelsAndPapsCorrectlyAtLongInterval)
 {
   TestLevelPapTransmission(2000);
 }


### PR DESCRIPTION
Implemented the remaining unit tests that I could think of for the process_sources side of things. The next unit tests will focus on the other functions in source_state.h.