### PR TITLE
Unit tests for source_state module part 4

### DIFF
--- a/src/sacn/source_state.c
+++ b/src/sacn/source_state.c
@@ -512,9 +512,9 @@ void update_paps(SacnSource* source_state, SacnSourceUniverse* universe_state, c
 // Needs lock
 void zero_levels_where_paps_are_zero(SacnSourceUniverse* universe_state)
 {
-  int level_count = universe_state->level_send_buf[SACN_PROPERTY_VALUE_COUNT_OFFSET] - 1;
-  int pap_count = universe_state->pap_send_buf[SACN_PROPERTY_VALUE_COUNT_OFFSET] - 1;
-  for (int i = 0; i < level_count; ++i)
+  uint16_t level_count = etcpal_unpack_u16b(&universe_state->level_send_buf[SACN_PROPERTY_VALUE_COUNT_OFFSET]) - 1;
+  uint16_t pap_count = etcpal_unpack_u16b(&universe_state->pap_send_buf[SACN_PROPERTY_VALUE_COUNT_OFFSET]) - 1;
+  for (uint16_t i = 0; i < level_count; ++i)
   {
     if ((i >= pap_count) || (universe_state->pap_send_buf[SACN_DATA_HEADER_SIZE + i] == 0))
       universe_state->level_send_buf[SACN_DATA_HEADER_SIZE + i] = 0;

--- a/tests/unit/state/source/test_source_state.cpp
+++ b/tests/unit/state/source/test_source_state.cpp
@@ -1805,3 +1805,13 @@ TEST_F(TestSourceState, DisablePapDataWorks)
   disable_pap_data(GetUniverse(source, universe));
   EXPECT_EQ(GetUniverse(source, universe)->has_pap_data, false);
 }
+
+TEST_F(TestSourceState, ClearSourceNetintsWorks)
+{
+  sacn_source_t source = AddSource(kTestSourceConfig);
+  AddUniverse(source, kTestUniverseConfig);
+
+  EXPECT_EQ(GetSource(source)->num_netints, NUM_TEST_NETINTS);
+  clear_source_netints(GetSource(source));
+  EXPECT_EQ(GetSource(source)->num_netints, 0u);
+}

--- a/tests/unit/state/source/test_source_state.cpp
+++ b/tests/unit/state/source/test_source_state.cpp
@@ -1108,3 +1108,15 @@ TEST_F(TestSourceState, InitializeSourceThreadWorks)
   initialize_source_thread();
   EXPECT_EQ(etcpal_thread_create_fake.call_count, 1u);
 }
+
+TEST_F(TestSourceState, GetNextSourceHandleWorks)
+{
+  sacn_source_t handle = get_next_source_handle();
+
+  for (int i = 0; i < 10; ++i)
+  {
+    sacn_source_t prev_handle = handle;
+    handle = get_next_source_handle();
+    EXPECT_EQ(handle, prev_handle + 1);
+  }
+}

--- a/tests/unit/state/source/test_source_state.cpp
+++ b/tests/unit/state/source/test_source_state.cpp
@@ -1690,3 +1690,43 @@ TEST_F(TestSourceState, SetSourceNameWorks)
     EXPECT_EQ(GetUniverse(source, universe)->pap_keep_alive_timer.reset_time, kTestGetMsValue);
   }
 }
+
+TEST_F(TestSourceState, GetSourceUniversesWorks)
+{
+  sacn_source_t source = AddSource(kTestSourceConfig);
+
+  SacnSourceUniverseConfig universe_config = kTestUniverseConfig;
+  for (int i = 0; i < 7; ++i)
+  {
+    AddUniverse(source, universe_config);
+    ++universe_config.universe;
+  }
+
+  uint16_t universes[7] = {0u};
+
+  size_t num_universes = get_source_universes(GetSource(source), universes, 1u);
+  EXPECT_EQ(num_universes, 7u);
+
+  EXPECT_EQ(universes[0], kTestUniverseConfig.universe);
+  for (uint16_t i = 1u; i < 7u; ++i)
+    EXPECT_EQ(universes[i], 0u);
+
+  num_universes = get_source_universes(GetSource(source), universes, 7u);
+  EXPECT_EQ(num_universes, 7u);
+
+  for (uint16_t i = 0u; i < 7u; ++i)
+    EXPECT_EQ(universes[i], kTestUniverseConfig.universe + i);
+
+  size_t num_terminating = 0u;
+  for (uint16_t universe = kTestUniverseConfig.universe; universe < (kTestUniverseConfig.universe + 7u); universe += 2u)
+  {
+    set_universe_terminating(GetUniverse(source, universe));
+    ++num_terminating;
+  }
+
+  num_universes = get_source_universes(GetSource(source), universes, 7u);
+  EXPECT_EQ(num_universes, 7u - num_terminating);
+
+  for (uint16_t i = 0u; i < (7u - num_terminating); ++i)
+    EXPECT_EQ(universes[i], kTestUniverseConfig.universe + (i * 2u) + 1u);
+}

--- a/tests/unit/state/source/test_source_state.cpp
+++ b/tests/unit/state/source/test_source_state.cpp
@@ -1411,3 +1411,30 @@ TEST_F(TestSourceState, SendUniverseMulticastWorks)
   send_universe_multicast(GetSource(source), GetUniverse(source, multicast_universe), kTestBuffer);
   EXPECT_EQ(sacn_send_multicast_fake.call_count, NUM_TEST_NETINTS);
 }
+
+TEST_F(TestSourceState, SetPreviewFlagWorks)
+{
+  sacn_source_t source = AddSource(kTestSourceConfig);
+  uint16_t universe = AddUniverse(source, kTestUniverseConfig);
+  InitTestData(source, universe, kTestBuffer, kTestBufferLength, kTestBuffer2, kTestBuffer2Length);
+
+  etcpal_getms_fake.return_val = kTestGetMsValue;
+
+  set_preview_flag(GetSource(source), GetUniverse(source, universe), true);
+
+  EXPECT_EQ(GetUniverse(source, universe)->send_preview, true);
+  EXPECT_NE(GetUniverse(source, universe)->level_send_buf[SACN_OPTS_OFFSET] & SACN_OPTVAL_PREVIEW, 0x00u);
+  EXPECT_NE(GetUniverse(source, universe)->pap_send_buf[SACN_OPTS_OFFSET] & SACN_OPTVAL_PREVIEW, 0x00u);
+  EXPECT_EQ(GetUniverse(source, universe)->level_keep_alive_timer.reset_time, kTestGetMsValue);
+  EXPECT_EQ(GetUniverse(source, universe)->pap_keep_alive_timer.reset_time, kTestGetMsValue);
+
+  etcpal_getms_fake.return_val = kTestGetMsValue2;
+
+  set_preview_flag(GetSource(source), GetUniverse(source, universe), false);
+
+  EXPECT_EQ(GetUniverse(source, universe)->send_preview, false);
+  EXPECT_EQ(GetUniverse(source, universe)->level_send_buf[SACN_OPTS_OFFSET] & SACN_OPTVAL_PREVIEW, 0x00u);
+  EXPECT_EQ(GetUniverse(source, universe)->pap_send_buf[SACN_OPTS_OFFSET] & SACN_OPTVAL_PREVIEW, 0x00u);
+  EXPECT_EQ(GetUniverse(source, universe)->level_keep_alive_timer.reset_time, kTestGetMsValue2);
+  EXPECT_EQ(GetUniverse(source, universe)->pap_keep_alive_timer.reset_time, kTestGetMsValue2);
+}

--- a/tests/unit/state/source/test_source_state.cpp
+++ b/tests/unit/state/source/test_source_state.cpp
@@ -1323,3 +1323,22 @@ TEST_F(TestSourceState, UpdateLevelsIncrementsActiveUniversesCorrectly)
                             kDisableForceSync);
   EXPECT_EQ(source_state->num_active_universes, 1u);
 }
+
+TEST_F(TestSourceState, IncrementSequenceNumberWorks)
+{
+  sacn_source_t source = AddSource(kTestSourceConfig);
+  uint16_t universe = AddUniverse(source, kTestUniverseConfig);
+
+  SacnSource* source_state = nullptr;
+  SacnSourceUniverse* universe_state = nullptr;
+  lookup_source_and_universe(source, universe, &source_state, &universe_state);
+
+  for (int i = 0; i < 10; ++i)
+  {
+    uint8_t old_seq_num = universe_state->seq_num;
+    increment_sequence_number(universe_state);
+    EXPECT_EQ(universe_state->seq_num, old_seq_num + 1u);
+    EXPECT_EQ(universe_state->level_send_buf[SACN_SEQ_OFFSET], universe_state->seq_num);
+    EXPECT_EQ(universe_state->pap_send_buf[SACN_SEQ_OFFSET], universe_state->seq_num);
+  }
+}

--- a/tests/unit/state/source/test_source_state.cpp
+++ b/tests/unit/state/source/test_source_state.cpp
@@ -1766,3 +1766,31 @@ TEST_F(TestSourceState, GetSourceUnicastDestsWorks)
   for (size_t i = 0u; i < (NUM_TEST_ADDRS - num_terminating); ++i)
     EXPECT_EQ(etcpal_ip_cmp(&destinations[i], &kTestRemoteAddrs[(i * 2) + 1]), 0);
 }
+
+TEST_F(TestSourceState, GetSourceUniverseNetintsWorks)
+{
+  sacn_source_t source = AddSource(kTestSourceConfig);
+  uint16_t universe = AddUniverse(source, kTestUniverseConfig);
+
+  EtcPalMcastNetintId netints[NUM_TEST_NETINTS] = {{kEtcPalIpTypeInvalid, 0u}};
+
+  size_t num_netints = get_source_universe_netints(GetUniverse(source, universe), netints, 1u);
+  EXPECT_EQ(num_netints, NUM_TEST_NETINTS);
+
+  EXPECT_EQ(netints[0].index, kTestNetints[0].iface.index);
+  EXPECT_EQ(netints[0].ip_type, kTestNetints[0].iface.ip_type);
+  for (size_t i = 1u; i < NUM_TEST_NETINTS; ++i)
+  {
+    EXPECT_EQ(netints[i].index, 0u);
+    EXPECT_EQ(netints[i].ip_type, kEtcPalIpTypeInvalid);
+  }
+
+  num_netints = get_source_universe_netints(GetUniverse(source, universe), netints, NUM_TEST_NETINTS);
+  EXPECT_EQ(num_netints, NUM_TEST_NETINTS);
+
+  for (size_t i = 0u; i < NUM_TEST_NETINTS; ++i)
+  {
+    EXPECT_EQ(netints[i].index, kTestNetints[i].iface.index);
+    EXPECT_EQ(netints[i].ip_type, kTestNetints[i].iface.ip_type);
+  }
+}

--- a/tests/unit/state/source/test_source_state.cpp
+++ b/tests/unit/state/source/test_source_state.cpp
@@ -24,6 +24,7 @@
 #include "etcpal/cpp/inet.h"
 #include "etcpal/cpp/uuid.h"
 #include "etcpal_mock/common.h"
+#include "etcpal_mock/thread.h"
 #include "etcpal_mock/timer.h"
 #include "sacn_mock/private/common.h"
 #include "sacn_mock/private/sockets.h"
@@ -312,6 +313,25 @@ protected:
 
   sacn_source_t next_source_handle_ = 0;
 };
+
+TEST_F(TestSourceState, DeinitJoinsInitializedThread)
+{
+  EXPECT_EQ(etcpal_thread_join_fake.call_count, 0u);
+
+  initialize_source_thread();
+  sacn_source_state_deinit();
+
+  EXPECT_EQ(etcpal_thread_join_fake.call_count, 1u);
+}
+
+TEST_F(TestSourceState, DeinitDoesNotJoinUninitializedThread)
+{
+  EXPECT_EQ(etcpal_thread_join_fake.call_count, 0u);
+
+  sacn_source_state_deinit();
+
+  EXPECT_EQ(etcpal_thread_join_fake.call_count, 0u);
+}
 
 TEST_F(TestSourceState, ProcessSourcesCountsSources)
 {

--- a/tests/unit/state/source/test_source_state.cpp
+++ b/tests/unit/state/source/test_source_state.cpp
@@ -1438,3 +1438,24 @@ TEST_F(TestSourceState, SetPreviewFlagWorks)
   EXPECT_EQ(GetUniverse(source, universe)->level_keep_alive_timer.reset_time, kTestGetMsValue2);
   EXPECT_EQ(GetUniverse(source, universe)->pap_keep_alive_timer.reset_time, kTestGetMsValue2);
 }
+
+TEST_F(TestSourceState, SetUniversePriorityWorks)
+{
+  sacn_source_t source = AddSource(kTestSourceConfig);
+  uint16_t universe = AddUniverse(source, kTestUniverseConfig);
+  InitTestData(source, universe, kTestBuffer, kTestBufferLength, kTestBuffer2, kTestBuffer2Length);
+
+  etcpal_getms_fake.return_val = kTestGetMsValue;
+  for (uint8_t priority = 1u; priority < 10u; ++priority)
+  {
+    set_universe_priority(GetSource(source), GetUniverse(source, universe), priority);
+
+    EXPECT_EQ(GetUniverse(source, universe)->priority, priority);
+    EXPECT_EQ(GetUniverse(source, universe)->level_send_buf[SACN_PRI_OFFSET], priority);
+    EXPECT_EQ(GetUniverse(source, universe)->pap_send_buf[SACN_PRI_OFFSET], priority);
+    EXPECT_EQ(GetUniverse(source, universe)->level_keep_alive_timer.reset_time, etcpal_getms_fake.return_val);
+    EXPECT_EQ(GetUniverse(source, universe)->pap_keep_alive_timer.reset_time, etcpal_getms_fake.return_val);
+
+    ++etcpal_getms_fake.return_val;
+  }
+}

--- a/tests/unit/state/source/test_source_state.cpp
+++ b/tests/unit/state/source/test_source_state.cpp
@@ -1602,3 +1602,45 @@ TEST_F(TestSourceState, SetUniverseTerminatingWorks)
     EXPECT_EQ(GetUniverse(source, universe)->unicast_dests[i].num_terminations_sent, 0);
   }
 }
+
+TEST_F(TestSourceState, SetSourceTerminatingWorks)
+{
+  sacn_source_t source = AddSource(kTestSourceConfig);
+
+  SacnSourceUniverseConfig universe_config = kTestUniverseConfig;
+  for (int i = 0; i < 3; ++i)
+  {
+    AddUniverse(source, universe_config);
+    ++universe_config.universe;
+  }
+
+  set_source_terminating(GetSource(source));
+  EXPECT_EQ(GetSource(source)->terminating, true);
+  for (uint16_t universe = kTestUniverseConfig.universe; universe < (kTestUniverseConfig.universe + 3u); ++universe)
+  {
+    EXPECT_EQ(GetUniverse(source, universe)->terminating, true);
+    EXPECT_EQ(GetUniverse(source, universe)->num_terminations_sent, 0);
+
+    GetUniverse(source, universe)->num_terminations_sent = 2;
+  }
+
+  set_source_terminating(GetSource(source));
+  EXPECT_EQ(GetSource(source)->terminating, true);
+  for (uint16_t universe = kTestUniverseConfig.universe; universe < (kTestUniverseConfig.universe + 3u); ++universe)
+  {
+    EXPECT_EQ(GetUniverse(source, universe)->terminating, true);
+    EXPECT_EQ(GetUniverse(source, universe)->num_terminations_sent, 2);
+
+    GetUniverse(source, universe)->terminating = false;
+  }
+
+  GetSource(source)->terminating = false;
+  
+  set_source_terminating(GetSource(source));
+  EXPECT_EQ(GetSource(source)->terminating, true);
+  for (uint16_t universe = kTestUniverseConfig.universe; universe < (kTestUniverseConfig.universe + 3u); ++universe)
+  {
+    EXPECT_EQ(GetUniverse(source, universe)->terminating, true);
+    EXPECT_EQ(GetUniverse(source, universe)->num_terminations_sent, 0);
+  }
+}

--- a/tests/unit/state/source/test_source_state.cpp
+++ b/tests/unit/state/source/test_source_state.cpp
@@ -1076,3 +1076,23 @@ TEST_F(TestSourceState, SourcesTerminateCorrectly)
 
   EXPECT_EQ(GetSource(source), nullptr);
 }
+
+TEST_F(TestSourceState, InitializeSourceThreadWorks)
+{
+  etcpal_thread_create_fake.custom_fake = [](etcpal_thread_t* id, const EtcPalThreadParams* params,
+                                             void (*thread_fn)(void*), void* thread_arg) {
+    EXPECT_NE(id, nullptr);
+    EXPECT_EQ(params->priority, (unsigned int)ETCPAL_THREAD_DEFAULT_PRIORITY);
+    EXPECT_EQ(params->stack_size, (unsigned int)ETCPAL_THREAD_DEFAULT_STACK);
+    EXPECT_EQ(strcmp(params->thread_name, ETCPAL_THREAD_DEFAULT_NAME), 0);
+    EXPECT_EQ(params->platform_data, nullptr);
+    EXPECT_NE(thread_fn, nullptr);
+    EXPECT_EQ(thread_arg, nullptr);
+
+    return kEtcPalErrOk;
+  };
+
+  EXPECT_EQ(etcpal_thread_create_fake.call_count, 0u);
+  initialize_source_thread();
+  EXPECT_EQ(etcpal_thread_create_fake.call_count, 1u);
+}

--- a/tests/unit/state/source/test_source_state.cpp
+++ b/tests/unit/state/source/test_source_state.cpp
@@ -1485,3 +1485,79 @@ TEST_F(TestSourceState, SetUnicastDestTerminatingWorks)
     EXPECT_EQ(GetUniverse(source, universe)->unicast_dests[i].num_terminations_sent, 0);
   }
 }
+
+TEST_F(TestSourceState, ResetLevelAndPapTransmissionSuppressionWorks)
+{
+  sacn_source_t source = AddSource(kTestSourceConfig);
+  uint16_t universe = AddUniverse(source, kTestUniverseConfig);
+  InitTestData(source, universe, kTestBuffer, kTestBufferLength, kTestBuffer2, kTestBuffer2Length);
+
+  GetUniverse(source, universe)->level_packets_sent_before_suppression = 4;
+  GetUniverse(source, universe)->pap_packets_sent_before_suppression = 4;
+  GetUniverse(source, universe)->level_keep_alive_timer.reset_time = 0u;
+  GetUniverse(source, universe)->level_keep_alive_timer.interval = 0u;
+  GetUniverse(source, universe)->pap_keep_alive_timer.reset_time = 0u;
+  GetUniverse(source, universe)->pap_keep_alive_timer.interval = 0u;
+
+  etcpal_getms_fake.return_val = kTestGetMsValue;
+  reset_transmission_suppression(GetSource(source), GetUniverse(source, universe), kResetLevelAndPap);
+
+  EXPECT_EQ(GetUniverse(source, universe)->level_packets_sent_before_suppression, 0);
+  EXPECT_EQ(GetUniverse(source, universe)->pap_packets_sent_before_suppression, 0);
+  EXPECT_EQ(GetUniverse(source, universe)->level_keep_alive_timer.reset_time, etcpal_getms_fake.return_val);
+  EXPECT_EQ(GetUniverse(source, universe)->pap_keep_alive_timer.reset_time, etcpal_getms_fake.return_val);
+  EXPECT_EQ(GetUniverse(source, universe)->level_keep_alive_timer.interval,
+            (uint32_t)kTestSourceConfig.keep_alive_interval);
+  EXPECT_EQ(GetUniverse(source, universe)->pap_keep_alive_timer.interval,
+            (uint32_t)kTestSourceConfig.keep_alive_interval);
+}
+
+TEST_F(TestSourceState, ResetLevelTransmissionSuppressionWorks)
+{
+  sacn_source_t source = AddSource(kTestSourceConfig);
+  uint16_t universe = AddUniverse(source, kTestUniverseConfig);
+  InitTestData(source, universe, kTestBuffer, kTestBufferLength, kTestBuffer2, kTestBuffer2Length);
+
+  GetUniverse(source, universe)->level_packets_sent_before_suppression = 4;
+  GetUniverse(source, universe)->pap_packets_sent_before_suppression = 4;
+  GetUniverse(source, universe)->level_keep_alive_timer.reset_time = 0u;
+  GetUniverse(source, universe)->level_keep_alive_timer.interval = 0u;
+  GetUniverse(source, universe)->pap_keep_alive_timer.reset_time = 0u;
+  GetUniverse(source, universe)->pap_keep_alive_timer.interval = 0u;
+
+  etcpal_getms_fake.return_val = kTestGetMsValue;
+  reset_transmission_suppression(GetSource(source), GetUniverse(source, universe), kResetLevel);
+
+  EXPECT_EQ(GetUniverse(source, universe)->level_packets_sent_before_suppression, 0);
+  EXPECT_EQ(GetUniverse(source, universe)->pap_packets_sent_before_suppression, 4);
+  EXPECT_EQ(GetUniverse(source, universe)->level_keep_alive_timer.reset_time, etcpal_getms_fake.return_val);
+  EXPECT_EQ(GetUniverse(source, universe)->pap_keep_alive_timer.reset_time, 0u);
+  EXPECT_EQ(GetUniverse(source, universe)->level_keep_alive_timer.interval,
+            (uint32_t)kTestSourceConfig.keep_alive_interval);
+  EXPECT_EQ(GetUniverse(source, universe)->pap_keep_alive_timer.interval, 0u);
+}
+
+TEST_F(TestSourceState, ResetPapTransmissionSuppressionWorks)
+{
+  sacn_source_t source = AddSource(kTestSourceConfig);
+  uint16_t universe = AddUniverse(source, kTestUniverseConfig);
+  InitTestData(source, universe, kTestBuffer, kTestBufferLength, kTestBuffer2, kTestBuffer2Length);
+
+  GetUniverse(source, universe)->level_packets_sent_before_suppression = 4;
+  GetUniverse(source, universe)->pap_packets_sent_before_suppression = 4;
+  GetUniverse(source, universe)->level_keep_alive_timer.reset_time = 0u;
+  GetUniverse(source, universe)->level_keep_alive_timer.interval = 0u;
+  GetUniverse(source, universe)->pap_keep_alive_timer.reset_time = 0u;
+  GetUniverse(source, universe)->pap_keep_alive_timer.interval = 0u;
+
+  etcpal_getms_fake.return_val = kTestGetMsValue;
+  reset_transmission_suppression(GetSource(source), GetUniverse(source, universe), kResetPap);
+
+  EXPECT_EQ(GetUniverse(source, universe)->level_packets_sent_before_suppression, 4);
+  EXPECT_EQ(GetUniverse(source, universe)->pap_packets_sent_before_suppression, 0);
+  EXPECT_EQ(GetUniverse(source, universe)->level_keep_alive_timer.reset_time, 0u);
+  EXPECT_EQ(GetUniverse(source, universe)->pap_keep_alive_timer.reset_time, etcpal_getms_fake.return_val);
+  EXPECT_EQ(GetUniverse(source, universe)->level_keep_alive_timer.interval, 0u);
+  EXPECT_EQ(GetUniverse(source, universe)->pap_keep_alive_timer.interval,
+            (uint32_t)kTestSourceConfig.keep_alive_interval);
+}

--- a/tests/unit/state/source/test_source_state.cpp
+++ b/tests/unit/state/source/test_source_state.cpp
@@ -1101,7 +1101,8 @@ TEST_F(TestSourceState, InitializeSourceThreadWorks)
     EXPECT_NE(id, nullptr);
     EXPECT_EQ(params->priority, (unsigned int)ETCPAL_THREAD_DEFAULT_PRIORITY);
     EXPECT_EQ(params->stack_size, (unsigned int)ETCPAL_THREAD_DEFAULT_STACK);
-    EXPECT_EQ(strcmp(params->thread_name, ETCPAL_THREAD_DEFAULT_NAME), 0);
+    if (params->thread_name)
+      EXPECT_EQ(strcmp(params->thread_name, ETCPAL_THREAD_DEFAULT_NAME), 0);
     EXPECT_EQ(params->platform_data, nullptr);
     EXPECT_NE(thread_fn, nullptr);
     EXPECT_EQ(thread_arg, nullptr);

--- a/tests/unit/state/source/test_source_state.cpp
+++ b/tests/unit/state/source/test_source_state.cpp
@@ -1794,3 +1794,14 @@ TEST_F(TestSourceState, GetSourceUniverseNetintsWorks)
     EXPECT_EQ(netints[i].ip_type, kTestNetints[i].iface.ip_type);
   }
 }
+
+TEST_F(TestSourceState, DisablePapDataWorks)
+{
+  sacn_source_t source = AddSource(kTestSourceConfig);
+  uint16_t universe = AddUniverse(source, kTestUniverseConfig);
+  InitTestData(source, universe, kTestBuffer, kTestBufferLength, kTestBuffer2, kTestBuffer2Length);
+
+  EXPECT_EQ(GetUniverse(source, universe)->has_pap_data, true);
+  disable_pap_data(GetUniverse(source, universe));
+  EXPECT_EQ(GetUniverse(source, universe)->has_pap_data, false);
+}

--- a/tests/unit/state/source/test_source_state.cpp
+++ b/tests/unit/state/source/test_source_state.cpp
@@ -1234,7 +1234,7 @@ TEST_F(TestSourceState, UpdateOnlyPapsSavesLevels)
   EXPECT_EQ(universe_state->pap_keep_alive_timer.reset_time, kTestGetMsValue2);
 }
 
-TEST_F(TestSourceState, ZeroingPapsZeroesLevels)
+TEST_F(TestSourceState, LevelsZeroWhereverPapsAreZeroed)
 {
   sacn_source_t source = AddSource(kTestSourceConfig);
   uint16_t universe = AddUniverse(source, kTestUniverseConfig);
@@ -1264,6 +1264,24 @@ TEST_F(TestSourceState, ZeroingPapsZeroesLevels)
     else
       EXPECT_EQ(universe_state->level_send_buf[SACN_DATA_HEADER_SIZE + i], 0u);
   }
+
+  update_levels_and_or_paps(source_state, universe_state, kTestBuffer, kTestBufferLength, nullptr, 0u,
+                            kDisableForceSync);
+
+  for (size_t i = 0u; i < kTestBufferLength; ++i)
+  {
+    if (i % 2)
+      EXPECT_GT(universe_state->level_send_buf[SACN_DATA_HEADER_SIZE + i], 0u);
+    else
+      EXPECT_EQ(universe_state->level_send_buf[SACN_DATA_HEADER_SIZE + i], 0u);
+  }
+
+  disable_pap_data(universe_state);
+  update_levels_and_or_paps(source_state, universe_state, kTestBuffer, kTestBufferLength, nullptr, 0u,
+                            kDisableForceSync);
+
+  for (size_t i = 0u; i < kTestBufferLength; ++i)
+    EXPECT_GT(universe_state->level_send_buf[SACN_DATA_HEADER_SIZE + i], 0u);
 
   update_levels_and_or_paps(source_state, universe_state, kTestBuffer, kTestBufferLength, &kTestPriority, 1u,
                             kDisableForceSync);

--- a/tests/unit/state/source/test_source_state.cpp
+++ b/tests/unit/state/source/test_source_state.cpp
@@ -1459,3 +1459,29 @@ TEST_F(TestSourceState, SetUniversePriorityWorks)
     ++etcpal_getms_fake.return_val;
   }
 }
+
+TEST_F(TestSourceState, SetUnicastDestTerminatingWorks)
+{
+  sacn_source_t source = AddSource(kTestSourceConfig);
+  uint16_t universe = AddUniverse(source, kTestUniverseConfig);
+  AddTestUnicastDests(source, universe);
+
+  for (int i = 0; i < NUM_TEST_ADDRS; ++i)
+  {
+    set_unicast_dest_terminating(&GetUniverse(source, universe)->unicast_dests[i]);
+    EXPECT_EQ(GetUniverse(source, universe)->unicast_dests[i].terminating, true);
+    EXPECT_EQ(GetUniverse(source, universe)->unicast_dests[i].num_terminations_sent, 0);
+
+    GetUniverse(source, universe)->unicast_dests[i].num_terminations_sent = 2;
+
+    set_unicast_dest_terminating(&GetUniverse(source, universe)->unicast_dests[i]);
+    EXPECT_EQ(GetUniverse(source, universe)->unicast_dests[i].terminating, true);
+    EXPECT_EQ(GetUniverse(source, universe)->unicast_dests[i].num_terminations_sent, 2);
+
+    GetUniverse(source, universe)->unicast_dests[i].terminating = false;
+
+    set_unicast_dest_terminating(&GetUniverse(source, universe)->unicast_dests[i]);
+    EXPECT_EQ(GetUniverse(source, universe)->unicast_dests[i].terminating, true);
+    EXPECT_EQ(GetUniverse(source, universe)->unicast_dests[i].num_terminations_sent, 0);
+  }
+}

--- a/tests/unit/state/source/test_source_state.cpp
+++ b/tests/unit/state/source/test_source_state.cpp
@@ -333,6 +333,18 @@ TEST_F(TestSourceState, DeinitDoesNotJoinUninitializedThread)
   EXPECT_EQ(etcpal_thread_join_fake.call_count, 0u);
 }
 
+TEST_F(TestSourceState, DeinitDoesNotJoinFailedThread)
+{
+  etcpal_thread_create_fake.return_val = kEtcPalErrSys;
+
+  EXPECT_EQ(etcpal_thread_join_fake.call_count, 0u);
+
+  initialize_source_thread();
+  sacn_source_state_deinit();
+
+  EXPECT_EQ(etcpal_thread_join_fake.call_count, 0u);
+}
+
 TEST_F(TestSourceState, ProcessSourcesCountsSources)
 {
   SacnSourceConfig config = kTestSourceConfig;

--- a/tests/unit/state/source/test_source_state.cpp
+++ b/tests/unit/state/source/test_source_state.cpp
@@ -1561,3 +1561,44 @@ TEST_F(TestSourceState, ResetPapTransmissionSuppressionWorks)
   EXPECT_EQ(GetUniverse(source, universe)->pap_keep_alive_timer.interval,
             (uint32_t)kTestSourceConfig.keep_alive_interval);
 }
+
+TEST_F(TestSourceState, SetUniverseTerminatingWorks)
+{
+  sacn_source_t source = AddSource(kTestSourceConfig);
+  uint16_t universe = AddUniverse(source, kTestUniverseConfig);
+  AddTestUnicastDests(source, universe);
+
+  set_universe_terminating(GetUniverse(source, universe));
+  EXPECT_EQ(GetUniverse(source, universe)->terminating, true);
+  EXPECT_EQ(GetUniverse(source, universe)->num_terminations_sent, 0);
+
+  for (int i = 0; i < NUM_TEST_ADDRS; ++i)
+    EXPECT_EQ(GetUniverse(source, universe)->unicast_dests[i].terminating, true);
+
+  GetUniverse(source, universe)->num_terminations_sent = 2;
+
+  for (int i = 0; i < NUM_TEST_ADDRS; ++i)
+    GetUniverse(source, universe)->unicast_dests[i].num_terminations_sent = 2;
+
+  set_universe_terminating(GetUniverse(source, universe));
+  EXPECT_EQ(GetUniverse(source, universe)->terminating, true);
+  EXPECT_EQ(GetUniverse(source, universe)->num_terminations_sent, 2);
+
+  for (int i = 0; i < NUM_TEST_ADDRS; ++i)
+    EXPECT_EQ(GetUniverse(source, universe)->unicast_dests[i].num_terminations_sent, 2);
+
+  GetUniverse(source, universe)->terminating = false;
+
+  for (int i = 0; i < NUM_TEST_ADDRS; ++i)
+    GetUniverse(source, universe)->unicast_dests[i].terminating = false;
+
+  set_universe_terminating(GetUniverse(source, universe));
+  EXPECT_EQ(GetUniverse(source, universe)->terminating, true);
+  EXPECT_EQ(GetUniverse(source, universe)->num_terminations_sent, 0);
+
+  for (int i = 0; i < NUM_TEST_ADDRS; ++i)
+  {
+    EXPECT_EQ(GetUniverse(source, universe)->unicast_dests[i].terminating, true);
+    EXPECT_EQ(GetUniverse(source, universe)->unicast_dests[i].num_terminations_sent, 0);
+  }
+}

--- a/tests/unit/state/source/test_source_state.cpp
+++ b/tests/unit/state/source/test_source_state.cpp
@@ -1668,7 +1668,10 @@ TEST_F(TestSourceState, SetSourceNameWorks)
   EXPECT_EQ(strncmp(name_in_discovery_buffer, kTestName, kTestNameLength), 0);
 
   for (int i = kTestNameLength; i < SACN_SOURCE_NAME_MAX_LEN; ++i)
+  {
+    EXPECT_EQ(GetSource(source)->name[i], '\0');
     EXPECT_EQ(name_in_discovery_buffer[i], '\0');
+  }
 
   for (uint16_t universe = kTestUniverseConfig.universe; universe < (kTestUniverseConfig.universe + 3u); ++universe)
   {


### PR DESCRIPTION
This is the remainder of the unit tests for the source_state.h functions. The remaining source unit testing work involves writing the unit tests for the source.h error cases, as well as for the C++ wrapper. These will probably end up being parts 5 and 6. Then I will most likely move on to the receiver unit tests, followed by completing test coverage for the internal modules.