### PR TITLE
Use etcpal::OpaqueId in C++ Source

### DIFF
--- a/examples/receiver/src/main.c
+++ b/examples/receiver/src/main.c
@@ -20,7 +20,7 @@
 #include <assert.h>
 #include <stdio.h>
 #include "etcpal/common.h"
-#include "etcpal/lock.h"
+#include "etcpal/mutex.h"
 #include "etcpal/thread.h"
 #include "etcpal/timer.h"
 #include "sacn/receiver.h"

--- a/include/sacn/cpp/source.h
+++ b/include/sacn/cpp/source.h
@@ -849,7 +849,7 @@ inline std::vector<EtcPalMcastNetintId> Source::GetNetworkInterfaces(uint16_t un
 /**
  * @brief Get the current handle to the underlying C sacn_source.
  *
- * @return The handle, which may or may not be valid.
+ * @return The handle, which will only be valid if the source has been successfully created using Startup().
  */
 inline constexpr Source::Handle Source::handle() const
 {

--- a/include/sacn/cpp/source.h
+++ b/include/sacn/cpp/source.h
@@ -294,7 +294,7 @@ inline etcpal::Error Source::Startup(const Settings& settings)
 inline void Source::Shutdown()
 {
   sacn_source_destroy(handle_.value());
-  handle_.SetValue(SACN_SOURCE_INVALID);
+  handle_.Clear();
 }
 
 /**

--- a/include/sacn/cpp/source.h
+++ b/include/sacn/cpp/source.h
@@ -39,6 +39,14 @@
 
 namespace sacn
 {
+
+namespace detail
+{
+class SourceHandleType
+{
+};
+};  // namespace detail
+
 /**
  * @ingroup sacn_source_cpp
  * @brief An instance of sACN Source functionality; see @ref using_source.
@@ -50,12 +58,8 @@ namespace sacn
 class Source
 {
 public:
-  struct HandleType
-  {
-  };
-
   /** A handle type used by the sACN library to identify source instances. */
-  using Handle = etcpal::OpaqueId<HandleType, sacn_source_t, SACN_SOURCE_INVALID>;
+  using Handle = etcpal::OpaqueId<detail::SourceHandleType, sacn_source_t, SACN_SOURCE_INVALID>;
 
   /**
    * @ingroup sacn_source_cpp

--- a/src/sacn/private/common.h
+++ b/src/sacn/private/common.h
@@ -29,7 +29,7 @@
 
 #include <limits.h>
 #include "etcpal/common.h"
-#include "etcpal/lock.h"
+#include "etcpal/mutex.h"
 #include "etcpal/log.h"
 #include "etcpal/rbtree.h"
 #include "etcpal/socket.h"


### PR DESCRIPTION
This PR involves updating EtcPal to the latest commit, fixing the resulting build failures, and finally switching Source::Handle to etcpal::OpaqueId.