### PR TITLE
Remove Draft Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,8 @@ documentation, please see the [documentation](http://etclabs.github.io/sACN).
 
 ## Standard Version
 
-The current version of this repository implements ANSI E1.31-2009. You can download the standard
-document for free from the [ESTA TSP downloads page](https://tsp.esta.org/tsp/documents/published_docs.php). 
-
-The 2016 and 2018 revisions of the standard are currently being implemented.
+This repository will implement ANSI E1.31-2018. It is currently in development. You can download the standard
+document for free from the [ESTA TSP downloads page](https://tsp.esta.org/tsp/documents/published_docs.php).
 
 ## About this ETCLabs Project
 

--- a/include/sacn/cpp/receiver.h
+++ b/include/sacn/cpp/receiver.h
@@ -211,8 +211,6 @@ public:
   std::vector<EtcPalMcastNetintId> GetNetworkInterfaces();
 
   // Lesser used functions.  These apply to all instances of this class.
-  static void SetStandardVersion(sacn_standard_version_t version);
-  static sacn_standard_version_t GetStandardVersion();
   static void SetExpiredWait(uint32_t wait_ms);
   static uint32_t GetExpiredWait();
 
@@ -455,31 +453,6 @@ inline std::vector<EtcPalMcastNetintId> Receiver::GetNetworkInterfaces()
 
   netints.resize(num_netints);
   return netints;
-}
-
-/**
- * @brief Set the current version of the sACN standard to which the module is listening.
- *
- * This is a global option across all listening receivers.
- *
- * @param[in] version Version of sACN to listen to.
- */
-inline void Receiver::SetStandardVersion(sacn_standard_version_t version)
-{
-  sacn_receiver_set_standard_version(version);
-}
-
-/**
- * @brief Get the current version of the sACN standard to which the module is listening.
- *
- * This is a global option across all listening receivers.
- *
- * @return Version of sACN to which the module is listening, or #kSacnStandardVersionNone if the module is
- *         not initialized.
- */
-inline sacn_standard_version_t Receiver::GetStandardVersion()
-{
-  sacn_receiver_get_standard_version();
 }
 
 /**

--- a/include/sacn/receiver.h
+++ b/include/sacn/receiver.h
@@ -67,15 +67,6 @@ typedef int sacn_receiver_t;
  */
 #define SACN_RECEIVER_INFINITE_SOURCES 0
 
-/** An identifier for a version of the sACN standard. */
-typedef enum
-{
-  kSacnStandardVersionNone,      /**< Neither the draft nor the ratified sACN version. */
-  kSacnStandardVersionDraft,     /**< The 2006 draft sACN standard version. */
-  kSacnStandardVersionPublished, /**< The current published sACN standard version. */
-  kSacnStandardVersionAll        /**< Both the current published and 2006 draft sACN standard version. */
-} sacn_standard_version_t;
-
 /**
  * @brief The default expired notification wait time.
  *
@@ -284,8 +275,6 @@ etcpal_error_t sacn_receiver_reset_networking_per_receiver(const SacnReceiverNet
                                                            size_t num_netint_lists);
 size_t sacn_receiver_get_network_interfaces(sacn_receiver_t handle, EtcPalMcastNetintId* netints, size_t netints_size);
 
-void sacn_receiver_set_standard_version(sacn_standard_version_t version);
-sacn_standard_version_t sacn_receiver_get_standard_version();
 void sacn_receiver_set_expired_wait(uint32_t wait_ms);
 uint32_t sacn_receiver_get_expired_wait();
 

--- a/src/sacn/private/pdu.h
+++ b/src/sacn/private/pdu.h
@@ -115,8 +115,6 @@ extern "C" {
 
 bool parse_sacn_data_packet(const uint8_t* buf, size_t buflen, SacnHeaderData* header, uint8_t* seq, bool* terminated,
                             const uint8_t** pdata);
-bool parse_draft_sacn_data_packet(const uint8_t* buf, size_t buflen, SacnHeaderData* header, uint8_t* seq,
-                                  bool* terminated, const uint8_t** pdata);
 int pack_sacn_root_layer(uint8_t* buf, uint16_t pdu_length, bool extended, const EtcPalUuid* source_cid);
 int pack_sacn_data_framing_layer(uint8_t* buf, uint16_t slot_count, uint32_t vector, const char* source_name,
                                  uint8_t priority, uint16_t sync_address, uint8_t seq_num, bool preview,

--- a/tests/unit/api/c/receiver/test_receiver.cpp
+++ b/tests/unit/api/c/receiver/test_receiver.cpp
@@ -131,21 +131,6 @@ protected:
   }
 };
 
-TEST_F(TestReceiver, SetStandardVersionWorks)
-{
-  // Initialization should set it to the default
-  EXPECT_EQ(sacn_receiver_get_standard_version(), kSacnStandardVersionAll);
-
-  sacn_receiver_set_standard_version(kSacnStandardVersionDraft);
-  EXPECT_EQ(sacn_receiver_get_standard_version(), kSacnStandardVersionDraft);
-  sacn_receiver_set_standard_version(kSacnStandardVersionPublished);
-  EXPECT_EQ(sacn_receiver_get_standard_version(), kSacnStandardVersionPublished);
-  sacn_receiver_set_standard_version(kSacnStandardVersionAll);
-  EXPECT_EQ(sacn_receiver_get_standard_version(), kSacnStandardVersionAll);
-  sacn_receiver_set_standard_version(kSacnStandardVersionNone);
-  EXPECT_EQ(sacn_receiver_get_standard_version(), kSacnStandardVersionNone);
-}
-
 TEST_F(TestReceiver, SetExpiredWaitWorks)
 {
   // Initialization should set it to the default

--- a/tests/unit/api/cpp/merge_receiver/test_cpp_merge_receiver.cpp
+++ b/tests/unit/api/cpp/merge_receiver/test_cpp_merge_receiver.cpp
@@ -58,6 +58,7 @@ protected:
   }
 };
 
-TEST_F(TestMergeReceiver, SetStandardVersionWorks)
+TEST_F(TestMergeReceiver, Foo)
 {
+  // TODO
 }

--- a/tests/unit/api/cpp/receiver/test_cpp_receiver.cpp
+++ b/tests/unit/api/cpp/receiver/test_cpp_receiver.cpp
@@ -58,8 +58,7 @@ protected:
   }
 };
 
-TEST_F(TestReceiver, SetStandardVersionWorks)
+TEST_F(TestReceiver, Foo)
 {
-  // Initialization should set it to the default
-  EXPECT_EQ(sacn_receiver_get_standard_version(), kSacnStandardVersionAll);
+  // TODO
 }


### PR DESCRIPTION
ETC is deprecating Draft sACN support, so there's no need to complicate the open source code. Therefore, draft support was removed from the code. The set/get standard version functionality was removed along with it. I also updated README.md to remove ties to older standards, but if you prefer the older version let me know.