### PR TITLE
Unit tests for receiver_state module part 1

### DIFF
--- a/src/sacn/receiver_state.c
+++ b/src/sacn/receiver_state.c
@@ -248,14 +248,15 @@ etcpal_error_t add_receiver_sockets(SacnReceiver* receiver)
                                  receiver->netints.netints, receiver->netints.num_netints, &receiver->ipv6_socket);
   }
 
-  if ((ipv4_res == kEtcPalErrNoNetints) && (ipv6_res == kEtcPalErrNoNetints))
-    return kEtcPalErrNoNetints;
-  else if (ipv4_res == kEtcPalErrNoNetints)
-    return ipv6_res;
-  else if (ipv6_res == kEtcPalErrNoNetints)
-    return ipv4_res;
-  else
-    return ipv6_res;
+  etcpal_error_t result =
+      (((ipv4_res == kEtcPalErrNoNetints) || (ipv4_res == kEtcPalErrOk)) && (ipv6_res != kEtcPalErrNoNetints))
+          ? ipv6_res
+          : ipv4_res;
+
+  if ((result != kEtcPalErrOk) && (ipv4_res == kEtcPalErrOk))
+    sacn_remove_receiver_socket(receiver->thread_id, &receiver->ipv4_socket, kCloseSocketNow);
+
+  return result;
 }
 
 void begin_sampling_period(SacnReceiver* receiver)

--- a/tests/unit/state/receiver/test_receiver_state.cpp
+++ b/tests/unit/state/receiver/test_receiver_state.cpp
@@ -119,3 +119,14 @@ TEST_F(TestReceiverState, InitializedThreadDeinitializes)
 
   EXPECT_EQ(get_recv_thread_context(0)->running, false);
 }
+
+TEST_F(TestReceiverState, UninitializedThreadDoesNotDeinitialize)
+{
+  EXPECT_EQ(etcpal_thread_join_fake.call_count, 0u);
+  EXPECT_EQ(sacn_cleanup_dead_sockets_fake.call_count, 0u);
+
+  sacn_receiver_state_deinit();
+
+  EXPECT_EQ(etcpal_thread_join_fake.call_count, 0u);
+  EXPECT_EQ(sacn_cleanup_dead_sockets_fake.call_count, 0u);
+}

--- a/tests/unit/state/receiver/test_receiver_state.cpp
+++ b/tests/unit/state/receiver/test_receiver_state.cpp
@@ -355,6 +355,23 @@ TEST_F(TestReceiverState, AssignReceiverToThreadHandlesThreadError)
   EXPECT_EQ(get_recv_thread_context(0)->receivers, nullptr);
 }
 
+TEST_F(TestReceiverState, RemoveReceiverFromThreadWorks)
+{
+  sacn_add_receiver_socket_fake.custom_fake = [](sacn_thread_id_t, etcpal_iptype_t, uint16_t,
+                                                 const EtcPalMcastNetintId*, size_t, etcpal_socket_t* socket) {
+    *socket = kTestSocket;
+    return kEtcPalErrOk;
+  };
+
+  SacnReceiver* receiver = AddReceiver();
+  EXPECT_EQ(assign_receiver_to_thread(receiver), kEtcPalErrOk);
+
+  remove_receiver_from_thread(receiver, kQueueSocketForClose);
+
+  EXPECT_EQ(sacn_remove_receiver_socket_fake.call_count, 2u);
+  EXPECT_EQ(get_recv_thread_context(0)->receivers, nullptr);
+}
+
 TEST_F(TestReceiverState, RemoveReceiverSocketsRemovesIpv4AndIpv6)
 {
   sacn_add_receiver_socket_fake.custom_fake = [](sacn_thread_id_t, etcpal_iptype_t, uint16_t,

--- a/tests/unit/state/receiver/test_receiver_state.cpp
+++ b/tests/unit/state/receiver/test_receiver_state.cpp
@@ -222,6 +222,16 @@ TEST_F(TestReceiverState, GetReceiverNetintsWorks)
   }
 }
 
+TEST_F(TestReceiverState, GetSetExpiredWaitWorks)
+{
+  set_expired_wait(1u);
+  EXPECT_EQ(get_expired_wait(), 1u);
+  set_expired_wait(10u);
+  EXPECT_EQ(get_expired_wait(), 10u);
+  set_expired_wait(100u);
+  EXPECT_EQ(get_expired_wait(), 100u);
+}
+
 TEST_F(TestReceiverState, RemoveAllReceiverSocketsRemovesIpv4AndIpv6)
 {
   sacn_add_receiver_socket_fake.custom_fake = [](sacn_thread_id_t, etcpal_iptype_t, uint16_t,

--- a/tests/unit/state/receiver/test_receiver_state.cpp
+++ b/tests/unit/state/receiver/test_receiver_state.cpp
@@ -472,6 +472,20 @@ TEST_F(TestReceiverState, AddReceiverSocketsHandlesNoIpv6Netints)
   EXPECT_EQ(sacn_add_receiver_socket_fake.call_count, 2u);
 }
 
+TEST_F(TestReceiverState, BeginSamplingPeriodWorks)
+{
+  SacnReceiver* receiver = AddReceiver();
+
+  EXPECT_EQ(receiver->sampling, false);
+  EXPECT_EQ(receiver->notified_sampling_started, false);
+
+  begin_sampling_period(receiver);
+
+  EXPECT_EQ(receiver->sampling, true);
+  EXPECT_EQ(receiver->notified_sampling_started, false);
+  EXPECT_EQ(receiver->sample_timer.interval, static_cast<uint32_t>(SACN_SAMPLE_TIME));
+}
+
 TEST_F(TestReceiverState, RemoveReceiverSocketsRemovesIpv4AndIpv6)
 {
   sacn_add_receiver_socket_fake.custom_fake = [](sacn_thread_id_t, etcpal_iptype_t, uint16_t,

--- a/tests/unit/state/receiver/test_receiver_state.cpp
+++ b/tests/unit/state/receiver/test_receiver_state.cpp
@@ -151,9 +151,12 @@ TEST_F(TestReceiverState, DeinitRemovesAllReceiverSockets)
                                                     socket_close_behavior_t close_behavior) {
     SacnReceiver* state = nullptr;
     lookup_receiver_by_universe(kTestUniverse, &state);
+
     EXPECT_EQ(thread_id, 0u);
     EXPECT_TRUE((socket == &state->ipv4_socket) || (socket == &state->ipv6_socket));
     EXPECT_EQ(close_behavior, kCloseSocketNow);
+
+    *socket = ETCPAL_SOCKET_INVALID;
   };
 
   EXPECT_EQ(sacn_remove_receiver_socket_fake.call_count, 0u);

--- a/tests/unit/state/receiver/test_receiver_state.cpp
+++ b/tests/unit/state/receiver/test_receiver_state.cpp
@@ -188,8 +188,8 @@ TEST_F(TestReceiverState, GetReceiverNetintsWorks)
 {
   SacnReceiver* receiver = AddReceiver(kTestUniverse);
 
-  std::vector<EtcPalMcastNetintId> netints(kTestNetints.size());
-  for (size_t i = 0u; i < kTestNetints.size(); ++i)
+  std::vector<EtcPalMcastNetintId> netints(kTestNetints.size() * 2u);
+  for (size_t i = 0u; i < (kTestNetints.size() * 2u); ++i)
   {
     netints[i].index = 0u;
     netints[i].ip_type = kEtcPalIpTypeInvalid;
@@ -200,7 +200,7 @@ TEST_F(TestReceiverState, GetReceiverNetintsWorks)
 
   EXPECT_EQ(netints[0].index, kTestNetints[0].iface.index);
   EXPECT_EQ(netints[0].ip_type, kTestNetints[0].iface.ip_type);
-  for (size_t i = 1u; i < kTestNetints.size(); ++i)
+  for (size_t i = 1u; i < netints.size(); ++i)
   {
     EXPECT_EQ(netints[i].index, 0u);
     EXPECT_EQ(netints[i].ip_type, kEtcPalIpTypeInvalid);
@@ -213,6 +213,12 @@ TEST_F(TestReceiverState, GetReceiverNetintsWorks)
   {
     EXPECT_EQ(netints[i].index, kTestNetints[i].iface.index);
     EXPECT_EQ(netints[i].ip_type, kTestNetints[i].iface.ip_type);
+  }
+
+  for (size_t i = kTestNetints.size(); i < netints.size(); ++i)
+  {
+    EXPECT_EQ(netints[i].index, 0u);
+    EXPECT_EQ(netints[i].ip_type, kEtcPalIpTypeInvalid);
   }
 }
 


### PR DESCRIPTION
These tests cover the receiver_state functions that directly interface with the receiver API layer. Next I'm going to expose the threaded functionality (probably with just one extra receiver_state.h function that gets called in a loop by the thread function) and unit test that as well, similar to the source, since it's a significant part of the implementation that should be unit tested.