### PR TITLE
Unit tests for receiver_state module part 2

### DIFF
--- a/src/sacn/private/common.h
+++ b/src/sacn/private/common.h
@@ -378,6 +378,8 @@ typedef struct SacnRecvThreadContext
   // This section is only touched from the thread, outside the lock.
   EtcPalPollContext poll_context;
   uint8_t recv_buf[SACN_MTU];
+  EtcPalTimer periodic_timer;
+  bool periodic_timer_started;
 } SacnRecvThreadContext;
 
 /******************************************************************************

--- a/src/sacn/private/receiver_state.h
+++ b/src/sacn/private/receiver_state.h
@@ -40,6 +40,7 @@ etcpal_error_t add_receiver_sockets(SacnReceiver* receiver);
 void begin_sampling_period(SacnReceiver* receiver);
 void remove_receiver_sockets(SacnReceiver* receiver, socket_close_behavior_t close_behavior);
 void remove_all_receiver_sockets(socket_close_behavior_t close_behavior);
+void iterate_thread(SacnRecvThreadContext* context, EtcPalTimer* periodic_timer);
 
 #ifdef __cplusplus
 }

--- a/src/sacn/private/receiver_state.h
+++ b/src/sacn/private/receiver_state.h
@@ -40,7 +40,7 @@ etcpal_error_t add_receiver_sockets(SacnReceiver* receiver);
 void begin_sampling_period(SacnReceiver* receiver);
 void remove_receiver_sockets(SacnReceiver* receiver, socket_close_behavior_t close_behavior);
 void remove_all_receiver_sockets(socket_close_behavior_t close_behavior);
-void iterate_thread(SacnRecvThreadContext* context, EtcPalTimer* periodic_timer);
+void iterate_thread(SacnRecvThreadContext* context);
 
 #ifdef __cplusplus
 }

--- a/src/sacn_mock/private/receiver_state.h
+++ b/src/sacn_mock/private/receiver_state.h
@@ -40,7 +40,7 @@ DECLARE_FAKE_VALUE_FUNC(etcpal_error_t, add_receiver_sockets, SacnReceiver*);
 DECLARE_FAKE_VOID_FUNC(begin_sampling_period, SacnReceiver*);
 DECLARE_FAKE_VOID_FUNC(remove_receiver_sockets, SacnReceiver*, socket_close_behavior_t);
 DECLARE_FAKE_VOID_FUNC(remove_all_receiver_sockets, socket_close_behavior_t);
-DECLARE_FAKE_VOID_FUNC(iterate_thread, SacnRecvThreadContext*, EtcPalTimer*);
+DECLARE_FAKE_VOID_FUNC(iterate_thread, SacnRecvThreadContext*);
 
 void sacn_receiver_state_reset_all_fakes(void);
 

--- a/src/sacn_mock/private/receiver_state.h
+++ b/src/sacn_mock/private/receiver_state.h
@@ -40,6 +40,7 @@ DECLARE_FAKE_VALUE_FUNC(etcpal_error_t, add_receiver_sockets, SacnReceiver*);
 DECLARE_FAKE_VOID_FUNC(begin_sampling_period, SacnReceiver*);
 DECLARE_FAKE_VOID_FUNC(remove_receiver_sockets, SacnReceiver*, socket_close_behavior_t);
 DECLARE_FAKE_VOID_FUNC(remove_all_receiver_sockets, socket_close_behavior_t);
+DECLARE_FAKE_VOID_FUNC(iterate_thread, SacnRecvThreadContext*, EtcPalTimer*);
 
 void sacn_receiver_state_reset_all_fakes(void);
 

--- a/src/sacn_mock/receiver_state.c
+++ b/src/sacn_mock/receiver_state.c
@@ -32,6 +32,7 @@ DEFINE_FAKE_VALUE_FUNC(etcpal_error_t, add_receiver_sockets, SacnReceiver*);
 DEFINE_FAKE_VOID_FUNC(begin_sampling_period, SacnReceiver*);
 DEFINE_FAKE_VOID_FUNC(remove_receiver_sockets, SacnReceiver*, socket_close_behavior_t);
 DEFINE_FAKE_VOID_FUNC(remove_all_receiver_sockets, socket_close_behavior_t);
+DEFINE_FAKE_VOID_FUNC(iterate_thread, SacnRecvThreadContext*, EtcPalTimer*);
 
 void sacn_receiver_state_reset_all_fakes(void)
 {
@@ -48,4 +49,5 @@ void sacn_receiver_state_reset_all_fakes(void)
   RESET_FAKE(begin_sampling_period);
   RESET_FAKE(remove_receiver_sockets);
   RESET_FAKE(remove_all_receiver_sockets);
+  RESET_FAKE(iterate_thread);
 }

--- a/src/sacn_mock/receiver_state.c
+++ b/src/sacn_mock/receiver_state.c
@@ -32,7 +32,7 @@ DEFINE_FAKE_VALUE_FUNC(etcpal_error_t, add_receiver_sockets, SacnReceiver*);
 DEFINE_FAKE_VOID_FUNC(begin_sampling_period, SacnReceiver*);
 DEFINE_FAKE_VOID_FUNC(remove_receiver_sockets, SacnReceiver*, socket_close_behavior_t);
 DEFINE_FAKE_VOID_FUNC(remove_all_receiver_sockets, socket_close_behavior_t);
-DEFINE_FAKE_VOID_FUNC(iterate_thread, SacnRecvThreadContext*, EtcPalTimer*);
+DEFINE_FAKE_VOID_FUNC(iterate_thread, SacnRecvThreadContext*);
 
 void sacn_receiver_state_reset_all_fakes(void)
 {

--- a/tests/unit/state/receiver/test_receiver_state.cpp
+++ b/tests/unit/state/receiver/test_receiver_state.cpp
@@ -714,3 +714,17 @@ TEST_F(TestReceiverThread, CleansDeadSockets)
     sacn_cleanup_dead_sockets_fake.call_count = i;
   }
 }
+
+TEST_F(TestReceiverThread, Reads)
+{
+  sacn_read_fake.custom_fake = [](SacnRecvThreadContext* recv_thread_context, SacnReadResult*) {
+    EXPECT_EQ(recv_thread_context, get_recv_thread_context(0u));
+    return kEtcPalErrTimedOut;
+  };
+
+  for (unsigned int i = 1u; i <= 10u; ++i)
+  {
+    iterate_thread(get_recv_thread_context(0u));
+    sacn_read_fake.call_count = i;
+  }
+}


### PR DESCRIPTION
While all the receiver_state.h functions had unit tests, the thread functionality did not have any unit tests for it. This is a significant part of the receiver_state code. Although this shouldn't typically be done, I brought an internal function (iterate_thread) into receiver_state.h purely so it could be accessed by unit tests. I did this because it was the best way I could think of to unit test the thread functionality, which covers the most important part of receiver_state. I will unit test this function very similarly to how I tested process_sources_and_lock in source_state. This will be a smaller PR because I wanted to get feedback earlier on if this is the right direction.