### PR TITLE
Fix bug in dmx_merger: remove PAP followed by add PAP can cause incorrect PAPs

### DIFF
--- a/src/sacn/dmx_merger.c
+++ b/src/sacn/dmx_merger.c
@@ -1666,6 +1666,7 @@ etcpal_error_t remove_sacn_dmx_merger_pap(sacn_dmx_merger_t merger, sacn_dmx_mer
     memset(source_state->source.address_priority,
            (source_state->source.universe_priority == 0) ? 1 : source_state->source.universe_priority,
            SACN_DMX_MERGER_MAX_SLOTS);
+    source_state->pap_count = SACN_DMX_MERGER_MAX_SLOTS;
 
     // Only merge priorities for levels that have come in.
     merge_new_priorities(merger_state, source_state, 0, source_state->source.valid_level_count);

--- a/tests/unit/api/c/dmx_merger/test_dmx_merger.cpp
+++ b/tests/unit/api/c/dmx_merger/test_dmx_merger.cpp
@@ -1369,6 +1369,28 @@ TEST_F(TestDmxMergerUpdate, StopSourcePapWorks)
   VerifyMergeResults();
 }
 
+TEST_F(TestDmxMergerUpdate, ShortPapAfterRemovePapReleasesTrailingSlots)
+{
+  static constexpr size_t kShortPapCount = 10u;
+  ASSERT_LT(kShortPapCount, static_cast<size_t>(SACN_DMX_MERGER_MAX_SLOTS));
+
+  const std::vector<uint8_t> full_levels(SACN_DMX_MERGER_MAX_SLOTS, 77u);
+  const std::vector<uint8_t> first_pap(kShortPapCount, 200u);
+  const std::vector<uint8_t> second_pap(kShortPapCount, 150u);
+
+  UpdateLevels(merge_source_1_, full_levels);
+  UpdateUniversePriority(merge_source_1_, kValidPriority);
+
+  UpdatePap(merge_source_1_, first_pap);
+
+  EXPECT_EQ(sacn_dmx_merger_remove_pap(merger_handle_, merge_source_1_), kEtcPalErrOk);
+
+  UpdatePap(merge_source_1_, second_pap);
+
+  UpdateExpectedMergeResults(merge_source_1_, kValidPriority, full_levels, second_pap);
+  VerifyMergeResults();
+}
+
 TEST_F(TestDmxMerger, StopSourcePapErrNotFoundWorks)
 {
   sacn_dmx_merger_source_t source = kSacnDmxMergerSourceInvalid;


### PR DESCRIPTION
Because sacn_dmx_merger_remove_pap() doesn't update the source's pap_count (it should reset it to the full slot count, as that's the result of spreading the universe priority across the full range), it can cause wrong behavior when PAP comes back with a short length, because trailing slot priorities past the new PAP length are not correctly zeroed.